### PR TITLE
Add more architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,9 +8,9 @@ base: core22
 confinement: strict
 compression: lzo
 architectures:
-  - build-on: [amd64]
-    build-for: [amd64]
-
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
 #slots:
   #butterfly:
     #interface: dbus


### PR DESCRIPTION
@CodeDoctorDE  I have tweaked the yaml so that the snap package supports two more architecture (arm64 and armhf) thsi will help your snap reach a more wider audience, tested it builds successfully.