### PR TITLE
Cleaned up the snap package & added a workflow to test it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,8 +344,6 @@ jobs:
       matrix:
         architecture:
           - amd64
-          # - armhf
-          - arm64
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,17 +339,13 @@ jobs:
   #          app/build/macos/Build/Products/Release/butterfly.app
   build-snap:
     name: Build Snap
-    on:
-    - push
-    jobs:
-      snapcraft-build:
-        runs-on: ubuntu-latest
-        strategy:
-          matrix:
-            architecture:
-            - amd64
-            # - armhf
-            - arm64
+    runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          architecture:
+          - amd64
+          # - armhf
+          - arm64
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,7 +350,7 @@ jobs:
             - amd64
             # - armhf
             - arm64
-      steps:
+    steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,6 +337,25 @@ jobs:
   #        name: macos-build
   #        path: |
   #          app/build/macos/Build/Products/Release/butterfly.app
+  build-snap:
+    name: Build Snap
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64]
+      fail-fast: false
+    steps:
+      - name: Checkout Git repository
+        uses: actions/checkout@v3
+      - name: Build Snap
+        uses: snapcore/action-build@v1
+        id: snapcraft-build
+        with:
+          snapcraft-args: "-v"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: butterfly-snap_x86-64
+          path: ${{ steps.snapcraft-build.outputs.snap }} 
   deploy:
     runs-on: ubuntu-22.04
     if: github.event_name == 'push'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,9 +340,9 @@ jobs:
   build-snap:
     name: Build Snap
     runs-on: ubuntu-latest
-      strategy:
-        matrix:
-          architecture:
+    strategy:
+      matrix:
+        architecture:
           - amd64
           # - armhf
           - arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,23 +339,30 @@ jobs:
   #          app/build/macos/Build/Products/Release/butterfly.app
   build-snap:
     name: Build Snap
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [x86_64]
-      fail-fast: false
-    steps:
-      - name: Checkout Git repository
-        uses: actions/checkout@v3
-      - name: Build Snap
-        uses: snapcore/action-build@v1
-        id: snapcraft-build
+    on:
+    - push
+    jobs:
+      snapcraft-build:
+        runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            architecture:
+            - amd64
+            # - armhf
+            - arm64
+      steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
         with:
-          snapcraft-args: "-v"
+          image: tonistiigi/binfmt@sha256:df15403e06a03c2f461c1f7938b171fda34a5849eb63a70e2a2109ed5a778bde
+      - uses: diddlesnaps/snapcraft-multiarch-action@v1
+        id: build
+        with:
+          architecture: ${{ matrix.architecture }}
       - uses: actions/upload-artifact@v3
         with:
-          name: butterfly-snap_x86-64
-          path: ${{ steps.snapcraft-build.outputs.snap }} 
+          name: butterfly-snap
+          path: ${{ steps.build.outputs.snap }}    
   deploy:
     runs-on: ubuntu-22.04
     if: github.event_name == 'push'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,8 +29,10 @@ apps:
 parts:
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: $(curl https://raw.githubusercontent.com/LinwoodDev/Butterfly/nightly/FLUTTER_VERSION)
+    #source-tag: $(curl https://raw.githubusercontent.com/LinwoodDev/Butterfly/nightly/FLUTTER_VERSION)
     plugin: nil
+    override-pull: |
+      git clone --recursive --branch $(curl https://raw.githubusercontent.com/LinwoodDev/Butterfly/nightly/FLUTTER_VERSION) https://github.com/flutter/flutter.git $CRAFT_PART_SRC
     override-build: |
       set -eux
       mkdir -p $CRAFT_PART_INSTALL/usr/bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,9 @@ website: https://github.com/LinwoodDev/Butterfly #for metadata in gnome-software
 license: AGPL-3.0 #for metadata
 architectures:
   - build-on: amd64
-  - build-on: arm64 # try to build on arm64, as per https://github.com/flutter/flutter/issues/56992
+  #- build-on: arm64 # try to build on arm64, as per https://github.com/flutter/flutter/issues/56992
+  # cannot build for arm64, check this action for more details
+  # https://github.com/soumyaDghosh/Butterfly/actions/runs/5017887799/jobs/8996588822
 apps:
   butterfly:
     command: butterfly

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ apps:
 parts:
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.10.0
+    source-tag: ${curl https://raw.githubusercontent.com/LinwoodDev/Butterfly/nightly/FLUTTER_VERSION}
     plugin: nil
     override-build: |
       set -eux

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ apps:
 parts:
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: ${curl https://raw.githubusercontent.com/LinwoodDev/Butterfly/nightly/FLUTTER_VERSION}
+    source-tag: $(curl https://raw.githubusercontent.com/LinwoodDev/Butterfly/nightly/FLUTTER_VERSION)
     plugin: nil
     override-build: |
       set -eux

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ apps:
 parts:
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.10.1
+    source-tag: 3.10.0
     plugin: nil
     override-build: |
       set -eux

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ base: core22
 confinement: strict
 compression: lzo
 title: 'Linwood Butterfly' #For future, if changes needed, it can be easily done from here
-issue: https://github.com/LinwoodDev/Butterfly/issues #for metadata
+issues: https://github.com/LinwoodDev/Butterfly/issues #for metadata
 website: https://github.com/LinwoodDev/Butterfly #for metadata in gnome-software, kde-discover
 license: AGPL-3.0 #for metadata
 architectures:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,9 +5,13 @@ icon: app/linux/debian/usr/share/icons/hicolor/256x256/apps/dev.linwood.butterfl
 base: core22
 confinement: strict
 compression: lzo
+title: 'Linwood Butterfly' #For future, if changes needed, it can be easily done from here
+issue: https://github.com/LinwoodDev/Butterfly/issues #for metadata
+website: https://github.com/LinwoodDev/Butterfly #for metadata in gnome-software, kde-discover
+license: AGPL-3.0 #for metadata
 architectures:
   - build-on: amd64
-
+  - build-on: arm64 # try to build on arm64, as per https://github.com/flutter/flutter/issues/56992
 apps:
   butterfly:
     command: butterfly

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,16 +1,13 @@
 name: butterfly
 grade: stable
 adopt-info: butterfly
-summary: Powerful, minimalistic, cross-platform, opensource note-taking app.
-description: |
-  Butterfly is a note app where your ideas come first. You can paint, add texts and export them easily on every device.
+icon: app/linux/debian/usr/share/icons/hicolor/256x256/apps/dev.linwood.butterfly.png
 base: core22
 confinement: strict
 compression: lzo
 architectures:
   - build-on: amd64
-    build-for: amd64
-  
+
 apps:
   butterfly:
     command: butterfly
@@ -21,26 +18,73 @@ apps:
       - optical-drive
       - removable-media
     common-id: dev.linwood.butterfly
-    desktop: usr/share/applications/dev.linwood.butterfly.desktop
+    desktop: meta/gui/butterfly.desktop
 
 parts:
-  butterfly:
-    plugin: dump
-    source: https://github.com/LinwoodDev/Butterfly.git
+  flutter-git:
+    source: https://github.com/flutter/flutter.git
+    source-tag: 3.10.1
+    plugin: nil
+    override-build: |
+      set -eux
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      mkdir -p $CRAFT_PART_INSTALL/usr/libexec
+      cp -r $CRAFT_PART_SRC $CRAFT_PART_INSTALL/usr/libexec/flutter
+      ln -sf $CRAFT_PART_INSTALL/usr/libexec/flutter/bin/flutter $CRAFT_PART_INSTALL/usr/bin/flutter
+      export PATH="$CRAFT_PART_INSTALL/usr/bin:$PATH"
+      flutter doctor
     build-packages:
-      - build-essential
-      - wget
+      - clang
+      - cmake
       - curl
+      - ninja-build
+      - unzip
+    override-prime: ''
+  butterfly:
+    after: [ flutter-git ]
+    plugin: nil
+    #plugin: flutter
+    source: https://github.com/LinwoodDev/Butterfly.git
+    source-tag: v2.0.0-alpha.3
+    source-subdir: app
+    build-snaps:
+      - cmake
+    build-packages:
+      - curl
+      - libsecret-1-dev
+      - libjsoncpp-dev
     override-pull: |
       craftctl default
-      craftctl set version=$(git describe --tags --abbrev=0)
-      VER="$(git describe --tags --abbrev=0)"
-      wget -q -O- https://github.com/LinwoodDev/Butterfly/releases/download/${VER}/linwood-butterfly-linux.tar.gz |\
-           tar xzf - --strip-components=1 -C $CRAFT_PART_SRC
+      craftctl set version=$(git describe --tags --abbrev=0 | cut -c 2-)
     override-build: |
       craftctl default
-      chmod a+x ./butterfly
+      set -eux
+      cd $CRAFT_PART_SRC_WORK
+      flutter pub get || true
+      flutter build linux --release --verbose --target lib/main.dart
+      cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/
+      mkdir -p $CRAFT_PART_INSTALL/metainfo
+      cp -r linux/debian/usr/share/metainfo/dev.linwood.butterfly.appdata.xml $CRAFT_PART_INSTALL/metainfo/
+      mkdir -p $CRAFT_PART_INSTALL/meta/gui
+      cp -r linux/debian/usr/share/icons/hicolor/256x256/apps/dev.linwood.butterfly.png $CRAFT_PART_INSTALL/meta/gui
+      mv linux/debian/usr/share/applications/dev.linwood.butterfly.desktop $CRAFT_PART_INSTALL/meta/gui/butterfly.desktop
+      #sed -i 's|Icon=dev.linwood.butterfly|Icon=dev.linwood.butterfly.png|' $CRAFT_PART_INSTALL/meta/gui/butterfly.desktop
     stage-packages:
       - libsecret-1-0
       - libjsoncpp25
-    parse-info: [usr/share/metainfo/dev.linwood.butterfly.appdata.xml]
+    parse-info: [ metainfo/dev.linwood.butterfly.appdata.xml ]
+  cleanup:
+    after:  # Make this part run last; list all your other parts here
+      - butterfly
+      - flutter-git
+    plugin: nil
+    build-snaps:  # List all content-snaps and base snaps you're using here
+      - core22
+      - gnome-42-2204
+      - gtk-common-themes
+    override-prime: |
+      set -eux
+      for snap in "core22" "gnome-42-2204" "gtk-common-themes" ; do  # List all content-snaps and base snaps you're using here
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
+      done
+      rm -rf $CRAFT_PRIME/usr/share/doc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,7 +61,8 @@ parts:
       - libjsoncpp-dev
     override-pull: |
       craftctl default
-      craftctl set version=$(git describe --tags --abbrev=0 | cut -c 2-)
+      git fetch --tags
+      craftctl set version=$(git tag --sort=-creatordate --list 'v*' --sort=-v:refname | head -n 1 | cut -c 2-)
     override-build: |
       craftctl default
       set -eux

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,9 +72,7 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/metainfo
       cp -r linux/debian/usr/share/metainfo/dev.linwood.butterfly.appdata.xml $CRAFT_PART_INSTALL/metainfo/
       mkdir -p $CRAFT_PART_INSTALL/meta/gui
-      cp -r linux/debian/usr/share/icons/hicolor/256x256/apps/dev.linwood.butterfly.png $CRAFT_PART_INSTALL/meta/gui
       mv linux/debian/usr/share/applications/dev.linwood.butterfly.desktop $CRAFT_PART_INSTALL/meta/gui/butterfly.desktop
-      #sed -i 's|Icon=dev.linwood.butterfly|Icon=dev.linwood.butterfly.png|' $CRAFT_PART_INSTALL/meta/gui/butterfly.desktop
     stage-packages:
       - libsecret-1-0
       - libjsoncpp25

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,7 +51,7 @@ parts:
     plugin: nil
     #plugin: flutter
     source: https://github.com/LinwoodDev/Butterfly.git
-    source-tag: v2.0.0-alpha.3
+    source-tag: nightly
     source-subdir: app
     build-snaps:
       - cmake


### PR DESCRIPTION
There is one more thing, that can be done, that's using the repo directly as source, without any `source-tag`. Thus will allow to make nightly snaps, pushed to edge channel.

Explaining my changes:

1. Using flutter git, and building from source, for better integrity and reduces the need of any file. In future when flutter stable will be updated, we can use the flutter plugin directly, without any flutter custom commands in `override-build`
2. Fixed the icon issue permanently, as the icon will be copied in the first place. The stable channel has it, and the edge channel may have fixed it, though, I have no explanation for it.
3. Added the metafile properly to adopt snap info from there and added various metadata for other store apps(May seem redundant though).