### PR TITLE
Add note data state

### DIFF
--- a/api/lib/src/converter/legacy.dart
+++ b/api/lib/src/converter/legacy.dart
@@ -13,8 +13,8 @@ Archive convertLegacyDataToArchive(Map<String, dynamic> data) {
     ...legacyNoteDataJsonMigrator(data),
   };
   final archive = Archive();
-  final reader = NoteData(archive);
-  reader.setAsset(kMetaArchiveFile, utf8.encode(jsonEncode(data)));
+  var reader = NoteData(archive);
+  reader = reader.setAsset(kMetaArchiveFile, utf8.encode(jsonEncode(data)));
   NoteFileType type = NoteFileType.document;
   try {
     type = NoteFileType.values.byName(data['type'] as String);
@@ -22,21 +22,23 @@ Archive convertLegacyDataToArchive(Map<String, dynamic> data) {
   switch (type) {
     case NoteFileType.pack:
       for (final palette in data['palettes'] ?? []) {
-        reader.setAsset('$kPalettesArchiveDirectory/${palette.name}.json',
+        reader = reader.setAsset(
+            '$kPalettesArchiveDirectory/${palette.name}.json',
             utf8.encode((palette)));
       }
       for (final style in data['styles'] ?? []) {
-        reader.setAsset('$kStylesArchiveDirectory/${style.name}.json',
+        reader = reader.setAsset('$kStylesArchiveDirectory/${style.name}.json',
             utf8.encode((style)));
       }
       for (final component in data['components'] ?? []) {
-        reader.setAsset('$kComponentsArchiveDirectory/${component.name}.json',
+        reader = reader.setAsset(
+            '$kComponentsArchiveDirectory/${component.name}.json',
             utf8.encode((component)));
       }
       break;
     case NoteFileType.template:
     case NoteFileType.document:
-      reader.setAsset(
+      reader = reader.setAsset(
           '$kPagesArchiveDirectory/default.json',
           utf8.encode(jsonEncode(
               type == NoteFileType.document ? data : data['document'])));
@@ -45,12 +47,12 @@ Archive convertLegacyDataToArchive(Map<String, dynamic> data) {
               utf8.encode(jsonEncode({'type': 'pack', ...e})))))
           .toList();
       for (final pack in packs) {
-        reader.setPack(pack);
+        reader = reader.setPack(pack);
       }
       final thumbnail = data['thumbnail'] as String?;
       if (thumbnail?.isNotEmpty == true) {
         final data = UriData.parse(thumbnail!).contentAsBytes();
-        reader.setThumbnail(data);
+        reader = reader.setThumbnail(data);
       }
   }
   return archive;

--- a/api/lib/src/models/data.dart
+++ b/api/lib/src/models/data.dart
@@ -98,6 +98,7 @@ class NoteData {
             ...state.added,
             path: Uint8List.fromList(data),
           },
+          removed: state.removed.where((element) => element != path).toList(),
         ),
       );
 
@@ -142,10 +143,10 @@ class NoteData {
   }
 
   @useResult
-  Iterable<String> getAssets(String path, [bool removeExtension = false]) => [
+  Iterable<String> getAssets(String path, [bool removeExtension = false]) => {
         ...archive.files.map((e) => e.name),
         ...state.added.keys,
-      ]
+      }
           .where((e) => e.startsWith(path) && !state.removed.contains(e))
           .map((e) => e.substring(path.length))
           .map((e) {
@@ -334,9 +335,10 @@ class NoteData {
   @useResult
   NoteData renamePage(String oldName, String newName) {
     final page = getPage(oldName);
+    final index = getPageIndex(oldName);
     if (page == null) return this;
     final noteData = removePage(oldName);
-    return noteData.setPage(page, newName);
+    return noteData.setPage(page, newName, index);
   }
 
   @useResult

--- a/api/lib/src/models/data.dart
+++ b/api/lib/src/models/data.dart
@@ -356,7 +356,6 @@ class NoteData {
     return setAsset(kInfoArchiveFile, utf8.encode(content));
   }
 
-  @useResult
   (NoteData, String) addImage(Uint8List data, String fileExtension,
           [String name = '']) =>
       addAsset(kImagesArchiveDirectory, data, fileExtension, name);

--- a/api/lib/src/models/data.dart
+++ b/api/lib/src/models/data.dart
@@ -286,7 +286,7 @@ class NoteData {
   }
 
   @useResult
-  NoteData reoderPage(String page, [int? newIndex]) {
+  NoteData reorderPage(String page, [int? newIndex]) {
     newIndex ??= getPages().length;
     final pageName = _getPageFileName(page);
     final index = getPageIndex(page);
@@ -485,7 +485,6 @@ class NoteData {
     return base64Encode(save());
   }
 
-  @useResult
   (NoteData, String) addPage([DocumentPage? page, int? index]) {
     var name = 'Page ${getPages().length + 1}';
     var i = 1;

--- a/api/lib/src/models/data.dart
+++ b/api/lib/src/models/data.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -7,7 +6,6 @@ import 'package:butterfly_api/src/converter/core.dart';
 import 'package:butterfly_api/src/models/info.dart';
 import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:rxdart/rxdart.dart';
 
 import '../../butterfly_text.dart';
 import '../converter/note.dart';
@@ -32,16 +30,12 @@ class NoteDataState with _$NoteDataState {
   factory NoteDataState.fromJson(dynamic json) => _$NoteDataStateFromJson(json);
 }
 
+@immutable
 class NoteData {
   final Archive archive;
-  final BehaviorSubject<NoteData> _controller = BehaviorSubject();
   final NoteDataState state;
 
-  Stream<NoteData> get onChange => _controller.stream;
-
-  NoteData(this.archive, [this.state = const NoteDataState()]) {
-    _controller.add(this);
-  }
+  NoteData(this.archive, [this.state = const NoteDataState()]);
 
   factory NoteData.fromData(Uint8List data, {bool disableMigrations = false}) {
     if (disableMigrations) {
@@ -74,10 +68,10 @@ class NoteData {
 
   String? get name => getMetadata()?.name;
 
-  set name(String? value) {
+  NoteData setName(String? value) {
     final meta = getMetadata();
-    if (meta == null || value == null) return;
-    setMetadata(meta.copyWith(name: value));
+    if (meta == null || value == null) return this;
+    return setMetadata(meta.copyWith(name: value));
   }
 
   Uint8List? getAsset(String path) {
@@ -94,24 +88,40 @@ class NoteData {
     return file.content;
   }
 
-  void setAsset(String path, List<int> data) {
-    state.added[path] = Uint8List.fromList(data);
-    _controller.add(this);
-  }
+  @useResult
+  NoteData _updateState(NoteDataState state) => NoteData(archive, state);
 
-  void removeAsset(String path) => removeAssets([path]);
+  @useResult
+  NoteData setAsset(String path, List<int> data) => _updateState(
+        state.copyWith(
+          added: {
+            ...state.added,
+            path: Uint8List.fromList(data),
+          },
+        ),
+      );
 
-  void removeAssets(List<String> path) {
-    state.removed.addAll(path);
-    state.added.removeWhere((key, value) => path.contains(key));
-    _controller.add(this);
-  }
+  @useResult
+  NoteData removeAsset(String path) => removeAssets([path]);
 
-  String addAsset(String path, List<int> data, String fileExtension,
+  @useResult
+  NoteData removeAssets(List<String> path) => _updateState(
+        state.copyWith(
+          removed: [
+            ...state.removed,
+            ...path,
+          ],
+          added: {
+            ...state.added,
+          }..removeWhere((key, value) => path.contains(key)),
+        ),
+      );
+
+  @useResult
+  (NoteData, String) addAsset(String path, List<int> data, String fileExtension,
       [String name = '']) {
     final newPath = '$path/${findUniqueName(path, fileExtension, name)}';
-    setAsset(newPath, data);
-    return newPath;
+    return (setAsset(newPath, data), newPath);
   }
 
   String _getFileName(String name, String fileExtension) =>
@@ -131,6 +141,7 @@ class NoteData {
     return getName();
   }
 
+  @useResult
   Iterable<String> getAssets(String path, [bool removeExtension = false]) => [
         ...archive.files.map((e) => e.name),
         ...state.added.keys,
@@ -145,10 +156,14 @@ class NoteData {
         return e.substring(0, startExtension);
       });
 
+  @useResult
   Uint8List? getThumbnail() => getAsset(kThumbnailArchiveFile);
 
-  void setThumbnail(Uint8List data) => setAsset(kThumbnailArchiveFile, data);
+  @useResult
+  NoteData setThumbnail(Uint8List data) =>
+      setAsset(kThumbnailArchiveFile, data);
 
+  @useResult
   FileMetadata? getMetadata() {
     final data = getAsset(kMetaArchiveFile);
     if (data == null) return null;
@@ -158,13 +173,13 @@ class NoteData {
     return FileMetadata.fromJson(json);
   }
 
-  void setMetadata(FileMetadata metadata) {
-    final content = jsonEncode(metadata.toJson());
-    setAsset(kMetaArchiveFile, utf8.encode(content));
-  }
+  @useResult
+  NoteData setMetadata(FileMetadata metadata) =>
+      setAsset(kMetaArchiveFile, utf8.encode(jsonEncode(metadata.toJson())));
 
   // Document specific
 
+  @useResult
   NoteData createTemplate({
     String? name,
     String? description,
@@ -172,11 +187,8 @@ class NoteData {
     Uint8List? thumbnail,
   }) {
     // Copy archive
-    final archive = Archive();
-    for (final file in this.archive.files) {
-      archive.addFile(ArchiveFile(file.name, file.size, file.content));
-    }
-    final template = NoteData(archive);
+    final archive = export();
+    var template = NoteData(archive);
     // Change metadata
     final metadata = getMetadata();
     final newMetadata = FileMetadata(
@@ -188,18 +200,15 @@ class NoteData {
       fileVersion: kFileVersion,
       directory: directory ?? metadata?.directory ?? '',
     );
-    template.setMetadata(newMetadata);
-    if (thumbnail != null) template.setThumbnail(thumbnail);
-    return NoteData(archive);
+    template = template.setMetadata(newMetadata);
+    if (thumbnail != null) template = template.setThumbnail(thumbnail);
+    return NoteData(template.export());
   }
 
+  @useResult
   NoteData createDocument({String name = '', DateTime? createdAt}) {
-    final archive = Archive();
-    for (var file in this.archive.files) {
-      archive
-          .addFile(ArchiveFile.noCompress(file.name, file.size, file.content));
-    }
-    final document = NoteData(archive);
+    final archive = export();
+    var document = NoteData(archive);
     final metadata = getMetadata();
     createdAt ??= DateTime.now().toUtc();
     final newMetadata = FileMetadata(
@@ -211,10 +220,11 @@ class NoteData {
       fileVersion: kFileVersion,
       directory: metadata?.directory ?? '',
     );
-    document.setMetadata(newMetadata);
+    document = document.setMetadata(newMetadata);
     return document;
   }
 
+  @useResult
   String? _getPageFileName(String name) {
     final pages = getPages(true);
     if (pages.contains(name)) {
@@ -229,6 +239,7 @@ class NoteData {
     return null;
   }
 
+  @useResult
   DocumentPage? getPage([String name = 'default']) {
     final data = getAsset(
         '$kPagesArchiveDirectory/${_getPageFileName(name) ?? name}.json');
@@ -240,35 +251,42 @@ class NoteData {
     return DocumentPage.fromJson(json);
   }
 
-  void setPage(DocumentPage page, [String name = 'default', int? index]) {
+  @useResult
+  NoteData setPage(DocumentPage page, [String name = 'default', int? index]) {
     final pages = getPages();
     final newIndex = index ?? pages.length;
     final content = jsonEncode(page.toJson());
+    var noteData = this;
     if (index != null) {
-      _realignPages(index);
+      noteData = _realignPages(index);
     }
-    setAsset(
+    return noteData.setAsset(
         '$kPagesArchiveDirectory/${_getPageFileName(name) ?? '$newIndex.$name'}.json',
         utf8.encode(content));
   }
 
-  void _realignPages(int index) {
+  @useResult
+  NoteData _realignPages(int index) {
     final pagesOrder = _getPagesOrder();
     final nextPages =
         pagesOrder.where((element) => element.$1 >= index).toList();
-    if (nextPages.isEmpty) return;
+    if (nextPages.isEmpty) return this;
     final nextPagesData = nextPages.map((e) => (e, getPage(e.$3))).toList();
-    removeAssets(
+    var noteData = this;
+    noteData = noteData.removeAssets(
         nextPages.map((e) => '$kPagesArchiveDirectory/${e.$3}.json').toList());
     var nextIndex = index + 1;
     for (final ((_, lastName, _), data) in nextPagesData) {
-      setAsset('$kPagesArchiveDirectory/$nextIndex.$lastName.json',
+      noteData = noteData.setAsset(
+          '$kPagesArchiveDirectory/$nextIndex.$lastName.json',
           utf8.encode(jsonEncode(data?.toJson())));
       nextIndex++;
     }
+    return noteData;
   }
 
-  void reoderPage(String page, [int? newIndex]) {
+  @useResult
+  NoteData reoderPage(String page, [int? newIndex]) {
     newIndex ??= getPages().length;
     final pageName = _getPageFileName(page);
     final index = getPageIndex(page);
@@ -277,13 +295,15 @@ class NoteData {
         index == null ||
         data == null ||
         index == newIndex) {
-      return;
+      return this;
     }
-    removeAsset('$kPagesArchiveDirectory/$pageName.json');
-    _realignPages(newIndex);
-    setPage(data, page, newIndex);
+    var noteData = removeAsset('$kPagesArchiveDirectory/$pageName.json');
+    noteData = noteData._realignPages(newIndex);
+    noteData = noteData.setPage(data, page, newIndex);
+    return noteData;
   }
 
+  @useResult
   List<(int, String, String)> _getPagesOrder() =>
       getAssets(kPagesArchiveDirectory, true).map((e) {
         if (e.contains('.')) {
@@ -297,24 +317,29 @@ class NoteData {
         return (-1, e, e);
       }).sorted((a, b) => a.$1.compareTo(b.$1));
 
+  @useResult
   List<String> getPages([bool realName = false]) =>
       _getPagesOrder().map((e) => realName ? e.$3 : e.$2).toList();
 
+  @useResult
   int? getPageIndex(String page) =>
       _getPagesOrder().firstWhereOrNull((element) => element.$2 == page)?.$1;
 
-  void removePage(String page) => removeAssets(_getPagesOrder()
+  @useResult
+  NoteData removePage(String page) => removeAssets(_getPagesOrder()
       .where((e) => e.$2 == page)
       .map((e) => '$kPagesArchiveDirectory/${e.$3}.json')
       .toList());
 
-  void renamePage(String oldName, String newName) {
+  @useResult
+  NoteData renamePage(String oldName, String newName) {
     final page = getPage(oldName);
-    if (page == null) return;
-    removePage(oldName);
-    setPage(page, newName);
+    if (page == null) return this;
+    final noteData = removePage(oldName);
+    return noteData.setPage(page, newName);
   }
 
+  @useResult
   DocumentInfo? getInfo() {
     final data = getAsset(kInfoArchiveFile);
     if (data == null) {
@@ -325,17 +350,22 @@ class NoteData {
     return DocumentInfo.fromJson(json);
   }
 
-  void setInfo(DocumentInfo info) {
+  @useResult
+  NoteData setInfo(DocumentInfo info) {
     final content = jsonEncode(info.toJson());
-    setAsset(kInfoArchiveFile, utf8.encode(content));
+    return setAsset(kInfoArchiveFile, utf8.encode(content));
   }
 
-  String addImage(Uint8List data, String fileExtension, [String name = '']) =>
+  @useResult
+  (NoteData, String) addImage(Uint8List data, String fileExtension,
+          [String name = '']) =>
       addAsset(kImagesArchiveDirectory, data, fileExtension, name);
 
+  @useResult
   Uint8List? getFont(String fontName) =>
       getAsset('$kFontsArchiveDirectory/$fontName');
 
+  @useResult
   NoteData? getPack(String packName) {
     final data = getAsset('$kPacksArchiveDirectory/$packName.bfly');
     if (data == null) {
@@ -344,25 +374,31 @@ class NoteData {
     return NoteData.fromData(data);
   }
 
-  void setPack(NoteData pack, [String? name]) {
+  @useResult
+  NoteData setPack(NoteData pack, [String? name]) {
     final data = ZipEncoder().encode(pack.archive);
     if (data != null) {
-      setAsset(
+      return setAsset(
           '$kPacksArchiveDirectory/${name ?? pack.getMetadata()?.name}.bfly',
           data);
     }
+    return this;
   }
 
-  void removePack(String name) =>
+  @useResult
+  NoteData removePack(String name) =>
       removeAsset('$kPacksArchiveDirectory/$name.bfly');
 
+  @useResult
   Iterable<String> getPacks() => getAssets(kPacksArchiveDirectory, true);
 
   // Pack specific
 
+  @useResult
   Iterable<String> getComponents() =>
       getAssets(kComponentsArchiveDirectory, true);
 
+  @useResult
   ButterflyComponent? getComponent(String componentName) {
     final data = getAsset('$kComponentsArchiveDirectory/$componentName.json');
     if (data == null) {
@@ -373,17 +409,19 @@ class NoteData {
     return ButterflyComponent.fromJson(json);
   }
 
-  void setComponent(ButterflyComponent component) {
-    final content = jsonEncode(component.toJson());
-    setAsset('$kComponentsArchiveDirectory/${component.name}.json',
-        utf8.encode(content));
-  }
+  @useResult
+  NoteData setComponent(ButterflyComponent component) => setAsset(
+      '$kComponentsArchiveDirectory/${component.name}.json',
+      utf8.encode(jsonEncode(component.toJson())));
 
-  void removeComponent(String name) =>
+  @useResult
+  NoteData removeComponent(String name) =>
       removeAsset('$kComponentsArchiveDirectory/$name.json');
 
+  @useResult
   Iterable<String> getStyles() => getAssets(kStylesArchiveDirectory, true);
 
+  @useResult
   TextStyleSheet? getStyle(String styleName) {
     final data = getAsset('$kStylesArchiveDirectory/$styleName.json');
     if (data == null) {
@@ -394,15 +432,18 @@ class NoteData {
     return TextStyleSheet.fromJson(json);
   }
 
-  void setStyle(TextStyleSheet style) {
+  @useResult
+  NoteData setStyle(TextStyleSheet style) {
     final content = jsonEncode(style.toJson());
-    setAsset(
+    return setAsset(
         '$kStylesArchiveDirectory/${style.name}.json', utf8.encode(content));
   }
 
-  void removeStyle(String name) =>
+  @useResult
+  NoteData removeStyle(String name) =>
       removeAsset('$kStylesArchiveDirectory/$name.json');
 
+  @useResult
   PackAssetLocation findStyle() {
     for (final pack in getPacks()) {
       final styles = getPack(pack)?.getStyles();
@@ -412,8 +453,10 @@ class NoteData {
     return PackAssetLocation.empty;
   }
 
+  @useResult
   Iterable<String> getPalettes() => getAssets(kPalettesArchiveDirectory, true);
 
+  @useResult
   ColorPalette? getPalette(String paletteName) {
     final data = getAsset('$kPalettesArchiveDirectory/$paletteName.json');
     if (data == null) {
@@ -424,33 +467,40 @@ class NoteData {
     return ColorPalette.fromJson(json);
   }
 
-  void setPalette(ColorPalette palette) {
+  @useResult
+  NoteData setPalette(ColorPalette palette) {
     final content = jsonEncode(palette.toJson());
-    setAsset('$kPalettesArchiveDirectory/${palette.name}.json',
+    return setAsset('$kPalettesArchiveDirectory/${palette.name}.json',
         utf8.encode(content));
   }
 
-  void removePalette(String name) =>
+  @useResult
+  NoteData removePalette(String name) =>
       removeAsset('$kPalettesArchiveDirectory/$name.json');
 
-  List<int> save() => ZipEncoder().encode(archive)!;
+  @useResult
+  List<int> save() => ZipEncoder().encode(export())!;
 
+  @useResult
   String toJson() {
     return base64Encode(save());
   }
 
-  String addPage([DocumentPage? page, int? index]) {
+  @useResult
+  (NoteData, String) addPage([DocumentPage? page, int? index]) {
     var name = 'Page ${getPages().length + 1}';
     var i = 1;
     while (getPages().contains(name)) {
       name = 'Page ${i++}';
     }
-    setPage(
-        page == null
-            ? DocumentPage()
-            : DocumentPage(backgrounds: page.backgrounds),
-        name,
-        index);
-    return name;
+    return (
+      setPage(
+          page == null
+              ? DocumentPage()
+              : DocumentPage(backgrounds: page.backgrounds),
+          name,
+          index),
+      name
+    );
   }
 }

--- a/api/lib/src/models/data.freezed.dart
+++ b/api/lib/src/models/data.freezed.dart
@@ -1,0 +1,197 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+NoteDataState _$NoteDataStateFromJson(Map<String, dynamic> json) {
+  return _NoteDataState.fromJson(json);
+}
+
+/// @nodoc
+mixin _$NoteDataState {
+  @Uint8ListJsonConverter()
+  Map<String, Uint8List> get added => throw _privateConstructorUsedError;
+  List<String> get removed => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $NoteDataStateCopyWith<NoteDataState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NoteDataStateCopyWith<$Res> {
+  factory $NoteDataStateCopyWith(
+          NoteDataState value, $Res Function(NoteDataState) then) =
+      _$NoteDataStateCopyWithImpl<$Res, NoteDataState>;
+  @useResult
+  $Res call(
+      {@Uint8ListJsonConverter() Map<String, Uint8List> added,
+      List<String> removed});
+}
+
+/// @nodoc
+class _$NoteDataStateCopyWithImpl<$Res, $Val extends NoteDataState>
+    implements $NoteDataStateCopyWith<$Res> {
+  _$NoteDataStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? added = null,
+    Object? removed = null,
+  }) {
+    return _then(_value.copyWith(
+      added: null == added
+          ? _value.added
+          : added // ignore: cast_nullable_to_non_nullable
+              as Map<String, Uint8List>,
+      removed: null == removed
+          ? _value.removed
+          : removed // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_NoteDataStateCopyWith<$Res>
+    implements $NoteDataStateCopyWith<$Res> {
+  factory _$$_NoteDataStateCopyWith(
+          _$_NoteDataState value, $Res Function(_$_NoteDataState) then) =
+      __$$_NoteDataStateCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@Uint8ListJsonConverter() Map<String, Uint8List> added,
+      List<String> removed});
+}
+
+/// @nodoc
+class __$$_NoteDataStateCopyWithImpl<$Res>
+    extends _$NoteDataStateCopyWithImpl<$Res, _$_NoteDataState>
+    implements _$$_NoteDataStateCopyWith<$Res> {
+  __$$_NoteDataStateCopyWithImpl(
+      _$_NoteDataState _value, $Res Function(_$_NoteDataState) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? added = null,
+    Object? removed = null,
+  }) {
+    return _then(_$_NoteDataState(
+      null == added
+          ? _value._added
+          : added // ignore: cast_nullable_to_non_nullable
+              as Map<String, Uint8List>,
+      null == removed
+          ? _value._removed
+          : removed // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_NoteDataState implements _NoteDataState {
+  const _$_NoteDataState(
+      [@Uint8ListJsonConverter()
+      final Map<String, Uint8List> added = const <String, Uint8List>{},
+      final List<String> removed = const <String>[]])
+      : _added = added,
+        _removed = removed;
+
+  factory _$_NoteDataState.fromJson(Map<String, dynamic> json) =>
+      _$$_NoteDataStateFromJson(json);
+
+  final Map<String, Uint8List> _added;
+  @override
+  @JsonKey()
+  @Uint8ListJsonConverter()
+  Map<String, Uint8List> get added {
+    if (_added is EqualUnmodifiableMapView) return _added;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_added);
+  }
+
+  final List<String> _removed;
+  @override
+  @JsonKey()
+  List<String> get removed {
+    if (_removed is EqualUnmodifiableListView) return _removed;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_removed);
+  }
+
+  @override
+  String toString() {
+    return 'NoteDataState(added: $added, removed: $removed)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_NoteDataState &&
+            const DeepCollectionEquality().equals(other._added, _added) &&
+            const DeepCollectionEquality().equals(other._removed, _removed));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_added),
+      const DeepCollectionEquality().hash(_removed));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_NoteDataStateCopyWith<_$_NoteDataState> get copyWith =>
+      __$$_NoteDataStateCopyWithImpl<_$_NoteDataState>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_NoteDataStateToJson(
+      this,
+    );
+  }
+}
+
+abstract class _NoteDataState implements NoteDataState {
+  const factory _NoteDataState(
+      [@Uint8ListJsonConverter() final Map<String, Uint8List> added,
+      final List<String> removed]) = _$_NoteDataState;
+
+  factory _NoteDataState.fromJson(Map<String, dynamic> json) =
+      _$_NoteDataState.fromJson;
+
+  @override
+  @Uint8ListJsonConverter()
+  Map<String, Uint8List> get added;
+  @override
+  List<String> get removed;
+  @override
+  @JsonKey(ignore: true)
+  _$$_NoteDataStateCopyWith<_$_NoteDataState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/api/lib/src/models/data.g.dart
+++ b/api/lib/src/models/data.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_NoteDataState _$$_NoteDataStateFromJson(Map json) => _$_NoteDataState(
+      (json['added'] as Map?)?.map(
+            (k, e) => MapEntry(k as String,
+                const Uint8ListJsonConverter().fromJson(e as String)),
+          ) ??
+          const <String, Uint8List>{},
+      (json['removed'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+          const <String>[],
+    );
+
+Map<String, dynamic> _$$_NoteDataStateToJson(_$_NoteDataState instance) =>
+    <String, dynamic>{
+      'added': instance.added
+          .map((k, e) => MapEntry(k, const Uint8ListJsonConverter().toJson(e))),
+      'removed': instance.removed,
+    };

--- a/api/lib/src/protocol/event.dart
+++ b/api/lib/src/protocol/event.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:replay_bloc/replay_bloc.dart';
 
@@ -14,9 +16,24 @@ enum DocumentPermission { read, write, admin }
 class DocumentEvent extends ReplayEvent with _$DocumentEvent {
   const DocumentEvent._();
 
+  const factory DocumentEvent.pageAdded(DocumentPage page, [int? index]) =
+      PageAdded;
+
   const factory DocumentEvent.pageChanged(
     String pageName,
   ) = PageChanged;
+
+  const factory DocumentEvent.pageReordered(String page, [int? newIndex]) =
+      PageReordered;
+
+  const factory DocumentEvent.pageRenamed(String oldName, String newName) =
+      PageRenamed;
+
+  const factory DocumentEvent.pageRemoved(String page) = PageRemoved;
+
+  const factory DocumentEvent.thumbnailCaptured(
+    @Uint8ListJsonConverter() Uint8List data,
+  ) = ThumbnailCaptured;
 
   const factory DocumentEvent.viewChanged(ViewOption view) = ViewChanged;
 

--- a/api/lib/src/protocol/event.freezed.dart
+++ b/api/lib/src/protocol/event.freezed.dart
@@ -16,8 +16,18 @@ final _privateConstructorUsedError = UnsupportedError(
 
 DocumentEvent _$DocumentEventFromJson(Map<String, dynamic> json) {
   switch (json['type']) {
+    case 'pageAdded':
+      return PageAdded.fromJson(json);
     case 'pageChanged':
       return PageChanged.fromJson(json);
+    case 'pageReordered':
+      return PageReordered.fromJson(json);
+    case 'pageRenamed':
+      return PageRenamed.fromJson(json);
+    case 'pageRemoved':
+      return PageRemoved.fromJson(json);
+    case 'thumbnailCaptured':
+      return ThumbnailCaptured.fromJson(json);
     case 'viewChanged':
       return ViewChanged.fromJson(json);
     case 'utilitiesChanged':
@@ -109,7 +119,13 @@ DocumentEvent _$DocumentEventFromJson(Map<String, dynamic> json) {
 mixin _$DocumentEvent {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -165,7 +181,13 @@ mixin _$DocumentEvent {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -214,7 +236,13 @@ mixin _$DocumentEvent {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -264,7 +292,12 @@ mixin _$DocumentEvent {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -314,7 +347,12 @@ mixin _$DocumentEvent {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -361,7 +399,12 @@ mixin _$DocumentEvent {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -426,6 +469,473 @@ class _$DocumentEventCopyWithImpl<$Res, $Val extends DocumentEvent>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$PageAddedCopyWith<$Res> {
+  factory _$$PageAddedCopyWith(
+          _$PageAdded value, $Res Function(_$PageAdded) then) =
+      __$$PageAddedCopyWithImpl<$Res>;
+  @useResult
+  $Res call({DocumentPage page, int? index});
+
+  $DocumentPageCopyWith<$Res> get page;
+}
+
+/// @nodoc
+class __$$PageAddedCopyWithImpl<$Res>
+    extends _$DocumentEventCopyWithImpl<$Res, _$PageAdded>
+    implements _$$PageAddedCopyWith<$Res> {
+  __$$PageAddedCopyWithImpl(
+      _$PageAdded _value, $Res Function(_$PageAdded) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? page = null,
+    Object? index = freezed,
+  }) {
+    return _then(_$PageAdded(
+      null == page
+          ? _value.page
+          : page // ignore: cast_nullable_to_non_nullable
+              as DocumentPage,
+      freezed == index
+          ? _value.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $DocumentPageCopyWith<$Res> get page {
+    return $DocumentPageCopyWith<$Res>(_value.page, (value) {
+      return _then(_value.copyWith(page: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PageAdded extends PageAdded {
+  const _$PageAdded(this.page, [this.index, final String? $type])
+      : $type = $type ?? 'pageAdded',
+        super._();
+
+  factory _$PageAdded.fromJson(Map<String, dynamic> json) =>
+      _$$PageAddedFromJson(json);
+
+  @override
+  final DocumentPage page;
+  @override
+  final int? index;
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'DocumentEvent.pageAdded(page: $page, index: $index)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageAdded &&
+            (identical(other.page, page) || other.page == page) &&
+            (identical(other.index, index) || other.index == index));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, page, index);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageAddedCopyWith<_$PageAdded> get copyWith =>
+      __$$PageAddedCopyWithImpl<_$PageAdded>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
+    required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
+    required TResult Function(ViewOption view) viewChanged,
+    required TResult Function(UtilitiesState state) utilitiesChanged,
+    required TResult Function(List<PadElement> elements) elementsCreated,
+    required TResult Function(Map<int, List<PadElement>> elements)
+        elementsChanged,
+    required TResult Function(List<int> elements) elementsRemoved,
+    required TResult Function(Arrangement arrangement, List<int> elements)
+        elementsArranged,
+    required TResult Function(String? name, String? description)
+        documentDescriptionChanged,
+    required TResult Function(String path) documentPathChanged,
+    required TResult Function(AssetLocation? location) documentSaved,
+    required TResult Function(Tool tool) toolCreated,
+    required TResult Function(Map<int, Tool> tools) toolsChanged,
+    required TResult Function(List<int> tools) toolsRemoved,
+    required TResult Function(int oldIndex, int newIndex) toolReordered,
+    required TResult Function(List<Background> backgrounds)
+        documentBackgroundsChanged,
+    required TResult Function(Waypoint waypoint) waypointCreated,
+    required TResult Function(int index, String name) waypointRenamed,
+    required TResult Function(int index) waypointRemoved,
+    required TResult Function(String oldName, String newName) layerRenamed,
+    required TResult Function(String name) layerRemoved,
+    required TResult Function(String name) layerElementsRemoved,
+    required TResult Function(String name) layerVisibilityChanged,
+    required TResult Function(String name) currentLayerChanged,
+    required TResult Function(String layer, List<int> elements)
+        elementsLayerChanged,
+    required TResult Function(
+            String directory, String? remote, bool deleteDocument)
+        templateCreated,
+    required TResult Function(List<Area> areas) areasCreated,
+    required TResult Function(List<String> areas) areasRemoved,
+    required TResult Function(String name, Area area) areaChanged,
+    required TResult Function(String name) currentAreaChanged,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetCreated,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetUpdated,
+    required TResult Function(String name) exportPresetRemoved,
+    required TResult Function(NoteData pack) packAdded,
+    required TResult Function(String name, NoteData pack) packUpdated,
+    required TResult Function(String name) packRemoved,
+    required TResult Function(AnimationTrack animation) animationAdded,
+    required TResult Function(String name, AnimationTrack animation)
+        animationUpdated,
+    required TResult Function(String name) animationRemoved,
+    required TResult Function(AnimationTrack track, bool fullScreen)
+        presentationModeEntered,
+    required TResult Function() presentationModeExited,
+    required TResult Function(int tick) presentationTick,
+  }) {
+    return pageAdded(page, index);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
+    TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult? Function(ViewOption view)? viewChanged,
+    TResult? Function(UtilitiesState state)? utilitiesChanged,
+    TResult? Function(List<PadElement> elements)? elementsCreated,
+    TResult? Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult? Function(List<int> elements)? elementsRemoved,
+    TResult? Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult? Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult? Function(String path)? documentPathChanged,
+    TResult? Function(AssetLocation? location)? documentSaved,
+    TResult? Function(Tool tool)? toolCreated,
+    TResult? Function(Map<int, Tool> tools)? toolsChanged,
+    TResult? Function(List<int> tools)? toolsRemoved,
+    TResult? Function(int oldIndex, int newIndex)? toolReordered,
+    TResult? Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult? Function(Waypoint waypoint)? waypointCreated,
+    TResult? Function(int index, String name)? waypointRenamed,
+    TResult? Function(int index)? waypointRemoved,
+    TResult? Function(String oldName, String newName)? layerRenamed,
+    TResult? Function(String name)? layerRemoved,
+    TResult? Function(String name)? layerElementsRemoved,
+    TResult? Function(String name)? layerVisibilityChanged,
+    TResult? Function(String name)? currentLayerChanged,
+    TResult? Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult? Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult? Function(List<Area> areas)? areasCreated,
+    TResult? Function(List<String> areas)? areasRemoved,
+    TResult? Function(String name, Area area)? areaChanged,
+    TResult? Function(String name)? currentAreaChanged,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult? Function(String name)? exportPresetRemoved,
+    TResult? Function(NoteData pack)? packAdded,
+    TResult? Function(String name, NoteData pack)? packUpdated,
+    TResult? Function(String name)? packRemoved,
+    TResult? Function(AnimationTrack animation)? animationAdded,
+    TResult? Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult? Function(String name)? animationRemoved,
+    TResult? Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult? Function()? presentationModeExited,
+    TResult? Function(int tick)? presentationTick,
+  }) {
+    return pageAdded?.call(page, index);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
+    TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult Function(ViewOption view)? viewChanged,
+    TResult Function(UtilitiesState state)? utilitiesChanged,
+    TResult Function(List<PadElement> elements)? elementsCreated,
+    TResult Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult Function(List<int> elements)? elementsRemoved,
+    TResult Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult Function(String path)? documentPathChanged,
+    TResult Function(AssetLocation? location)? documentSaved,
+    TResult Function(Tool tool)? toolCreated,
+    TResult Function(Map<int, Tool> tools)? toolsChanged,
+    TResult Function(List<int> tools)? toolsRemoved,
+    TResult Function(int oldIndex, int newIndex)? toolReordered,
+    TResult Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult Function(Waypoint waypoint)? waypointCreated,
+    TResult Function(int index, String name)? waypointRenamed,
+    TResult Function(int index)? waypointRemoved,
+    TResult Function(String oldName, String newName)? layerRenamed,
+    TResult Function(String name)? layerRemoved,
+    TResult Function(String name)? layerElementsRemoved,
+    TResult Function(String name)? layerVisibilityChanged,
+    TResult Function(String name)? currentLayerChanged,
+    TResult Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult Function(List<Area> areas)? areasCreated,
+    TResult Function(List<String> areas)? areasRemoved,
+    TResult Function(String name, Area area)? areaChanged,
+    TResult Function(String name)? currentAreaChanged,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult Function(String name)? exportPresetRemoved,
+    TResult Function(NoteData pack)? packAdded,
+    TResult Function(String name, NoteData pack)? packUpdated,
+    TResult Function(String name)? packRemoved,
+    TResult Function(AnimationTrack animation)? animationAdded,
+    TResult Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult Function(String name)? animationRemoved,
+    TResult Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult Function()? presentationModeExited,
+    TResult Function(int tick)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (pageAdded != null) {
+      return pageAdded(page, index);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
+    required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
+    required TResult Function(ViewChanged value) viewChanged,
+    required TResult Function(UtilitiesChanged value) utilitiesChanged,
+    required TResult Function(ElementsCreated value) elementsCreated,
+    required TResult Function(ElementsChanged value) elementsChanged,
+    required TResult Function(ElementsRemoved value) elementsRemoved,
+    required TResult Function(ElementsArranged value) elementsArranged,
+    required TResult Function(DocumentDescriptionChanged value)
+        documentDescriptionChanged,
+    required TResult Function(DocumentPathChanged value) documentPathChanged,
+    required TResult Function(DocumentSaved value) documentSaved,
+    required TResult Function(ToolCreated value) toolCreated,
+    required TResult Function(ToolsChanged value) toolsChanged,
+    required TResult Function(ToolsRemoved value) toolsRemoved,
+    required TResult Function(ToolReordered value) toolReordered,
+    required TResult Function(DocumentBackgroundsChanged value)
+        documentBackgroundsChanged,
+    required TResult Function(WaypointCreated value) waypointCreated,
+    required TResult Function(WaypointRenamed value) waypointRenamed,
+    required TResult Function(WaypointRemoved value) waypointRemoved,
+    required TResult Function(LayerRenamed value) layerRenamed,
+    required TResult Function(LayerRemoved value) layerRemoved,
+    required TResult Function(LayerElementsRemoved value) layerElementsRemoved,
+    required TResult Function(LayerVisibilityChanged value)
+        layerVisibilityChanged,
+    required TResult Function(CurrentLayerChanged value) currentLayerChanged,
+    required TResult Function(ElementsLayerChanged value) elementsLayerChanged,
+    required TResult Function(TemplateCreated value) templateCreated,
+    required TResult Function(AreasCreated value) areasCreated,
+    required TResult Function(AreasRemoved value) areasRemoved,
+    required TResult Function(AreaChanged value) areaChanged,
+    required TResult Function(CurrentAreaChanged value) currentAreaChanged,
+    required TResult Function(ExportPresetCreated value) exportPresetCreated,
+    required TResult Function(ExportPresetUpdated value) exportPresetUpdated,
+    required TResult Function(ExportPresetRemoved value) exportPresetRemoved,
+    required TResult Function(PackAdded value) packAdded,
+    required TResult Function(PackUpdated value) packUpdated,
+    required TResult Function(PackRemoved value) packRemoved,
+    required TResult Function(AnimationAdded value) animationAdded,
+    required TResult Function(AnimationUpdated value) animationUpdated,
+    required TResult Function(AnimationRemoved value) animationRemoved,
+    required TResult Function(PresentationModeEntered value)
+        presentationModeEntered,
+    required TResult Function(PresentationModeExited value)
+        presentationModeExited,
+    required TResult Function(PresentationTick value) presentationTick,
+  }) {
+    return pageAdded(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
+    TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult? Function(ViewChanged value)? viewChanged,
+    TResult? Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult? Function(ElementsCreated value)? elementsCreated,
+    TResult? Function(ElementsChanged value)? elementsChanged,
+    TResult? Function(ElementsRemoved value)? elementsRemoved,
+    TResult? Function(ElementsArranged value)? elementsArranged,
+    TResult? Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult? Function(DocumentPathChanged value)? documentPathChanged,
+    TResult? Function(DocumentSaved value)? documentSaved,
+    TResult? Function(ToolCreated value)? toolCreated,
+    TResult? Function(ToolsChanged value)? toolsChanged,
+    TResult? Function(ToolsRemoved value)? toolsRemoved,
+    TResult? Function(ToolReordered value)? toolReordered,
+    TResult? Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult? Function(WaypointCreated value)? waypointCreated,
+    TResult? Function(WaypointRenamed value)? waypointRenamed,
+    TResult? Function(WaypointRemoved value)? waypointRemoved,
+    TResult? Function(LayerRenamed value)? layerRenamed,
+    TResult? Function(LayerRemoved value)? layerRemoved,
+    TResult? Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult? Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult? Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult? Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult? Function(TemplateCreated value)? templateCreated,
+    TResult? Function(AreasCreated value)? areasCreated,
+    TResult? Function(AreasRemoved value)? areasRemoved,
+    TResult? Function(AreaChanged value)? areaChanged,
+    TResult? Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult? Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult? Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult? Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult? Function(PackAdded value)? packAdded,
+    TResult? Function(PackUpdated value)? packUpdated,
+    TResult? Function(PackRemoved value)? packRemoved,
+    TResult? Function(AnimationAdded value)? animationAdded,
+    TResult? Function(AnimationUpdated value)? animationUpdated,
+    TResult? Function(AnimationRemoved value)? animationRemoved,
+    TResult? Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult? Function(PresentationModeExited value)? presentationModeExited,
+    TResult? Function(PresentationTick value)? presentationTick,
+  }) {
+    return pageAdded?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
+    TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult Function(ViewChanged value)? viewChanged,
+    TResult Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult Function(ElementsCreated value)? elementsCreated,
+    TResult Function(ElementsChanged value)? elementsChanged,
+    TResult Function(ElementsRemoved value)? elementsRemoved,
+    TResult Function(ElementsArranged value)? elementsArranged,
+    TResult Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult Function(DocumentPathChanged value)? documentPathChanged,
+    TResult Function(DocumentSaved value)? documentSaved,
+    TResult Function(ToolCreated value)? toolCreated,
+    TResult Function(ToolsChanged value)? toolsChanged,
+    TResult Function(ToolsRemoved value)? toolsRemoved,
+    TResult Function(ToolReordered value)? toolReordered,
+    TResult Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult Function(WaypointCreated value)? waypointCreated,
+    TResult Function(WaypointRenamed value)? waypointRenamed,
+    TResult Function(WaypointRemoved value)? waypointRemoved,
+    TResult Function(LayerRenamed value)? layerRenamed,
+    TResult Function(LayerRemoved value)? layerRemoved,
+    TResult Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult Function(TemplateCreated value)? templateCreated,
+    TResult Function(AreasCreated value)? areasCreated,
+    TResult Function(AreasRemoved value)? areasRemoved,
+    TResult Function(AreaChanged value)? areaChanged,
+    TResult Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult Function(PackAdded value)? packAdded,
+    TResult Function(PackUpdated value)? packUpdated,
+    TResult Function(PackRemoved value)? packRemoved,
+    TResult Function(AnimationAdded value)? animationAdded,
+    TResult Function(AnimationUpdated value)? animationUpdated,
+    TResult Function(AnimationRemoved value)? animationRemoved,
+    TResult Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult Function(PresentationModeExited value)? presentationModeExited,
+    TResult Function(PresentationTick value)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (pageAdded != null) {
+      return pageAdded(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PageAddedToJson(
+      this,
+    );
+  }
+}
+
+abstract class PageAdded extends DocumentEvent {
+  const factory PageAdded(final DocumentPage page, [final int? index]) =
+      _$PageAdded;
+  const PageAdded._() : super._();
+
+  factory PageAdded.fromJson(Map<String, dynamic> json) = _$PageAdded.fromJson;
+
+  DocumentPage get page;
+  int? get index;
+  @JsonKey(ignore: true)
+  _$$PageAddedCopyWith<_$PageAdded> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -502,7 +1012,13 @@ class _$PageChanged extends PageChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -561,7 +1077,13 @@ class _$PageChanged extends PageChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -613,7 +1135,13 @@ class _$PageChanged extends PageChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -669,7 +1197,12 @@ class _$PageChanged extends PageChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -722,7 +1255,12 @@ class _$PageChanged extends PageChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -772,7 +1310,12 @@ class _$PageChanged extends PageChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -841,6 +1384,1824 @@ abstract class PageChanged extends DocumentEvent {
   String get pageName;
   @JsonKey(ignore: true)
   _$$PageChangedCopyWith<_$PageChanged> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PageReorderedCopyWith<$Res> {
+  factory _$$PageReorderedCopyWith(
+          _$PageReordered value, $Res Function(_$PageReordered) then) =
+      __$$PageReorderedCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String page, int? newIndex});
+}
+
+/// @nodoc
+class __$$PageReorderedCopyWithImpl<$Res>
+    extends _$DocumentEventCopyWithImpl<$Res, _$PageReordered>
+    implements _$$PageReorderedCopyWith<$Res> {
+  __$$PageReorderedCopyWithImpl(
+      _$PageReordered _value, $Res Function(_$PageReordered) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? page = null,
+    Object? newIndex = freezed,
+  }) {
+    return _then(_$PageReordered(
+      null == page
+          ? _value.page
+          : page // ignore: cast_nullable_to_non_nullable
+              as String,
+      freezed == newIndex
+          ? _value.newIndex
+          : newIndex // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PageReordered extends PageReordered {
+  const _$PageReordered(this.page, [this.newIndex, final String? $type])
+      : $type = $type ?? 'pageReordered',
+        super._();
+
+  factory _$PageReordered.fromJson(Map<String, dynamic> json) =>
+      _$$PageReorderedFromJson(json);
+
+  @override
+  final String page;
+  @override
+  final int? newIndex;
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'DocumentEvent.pageReordered(page: $page, newIndex: $newIndex)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageReordered &&
+            (identical(other.page, page) || other.page == page) &&
+            (identical(other.newIndex, newIndex) ||
+                other.newIndex == newIndex));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, page, newIndex);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageReorderedCopyWith<_$PageReordered> get copyWith =>
+      __$$PageReorderedCopyWithImpl<_$PageReordered>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
+    required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
+    required TResult Function(ViewOption view) viewChanged,
+    required TResult Function(UtilitiesState state) utilitiesChanged,
+    required TResult Function(List<PadElement> elements) elementsCreated,
+    required TResult Function(Map<int, List<PadElement>> elements)
+        elementsChanged,
+    required TResult Function(List<int> elements) elementsRemoved,
+    required TResult Function(Arrangement arrangement, List<int> elements)
+        elementsArranged,
+    required TResult Function(String? name, String? description)
+        documentDescriptionChanged,
+    required TResult Function(String path) documentPathChanged,
+    required TResult Function(AssetLocation? location) documentSaved,
+    required TResult Function(Tool tool) toolCreated,
+    required TResult Function(Map<int, Tool> tools) toolsChanged,
+    required TResult Function(List<int> tools) toolsRemoved,
+    required TResult Function(int oldIndex, int newIndex) toolReordered,
+    required TResult Function(List<Background> backgrounds)
+        documentBackgroundsChanged,
+    required TResult Function(Waypoint waypoint) waypointCreated,
+    required TResult Function(int index, String name) waypointRenamed,
+    required TResult Function(int index) waypointRemoved,
+    required TResult Function(String oldName, String newName) layerRenamed,
+    required TResult Function(String name) layerRemoved,
+    required TResult Function(String name) layerElementsRemoved,
+    required TResult Function(String name) layerVisibilityChanged,
+    required TResult Function(String name) currentLayerChanged,
+    required TResult Function(String layer, List<int> elements)
+        elementsLayerChanged,
+    required TResult Function(
+            String directory, String? remote, bool deleteDocument)
+        templateCreated,
+    required TResult Function(List<Area> areas) areasCreated,
+    required TResult Function(List<String> areas) areasRemoved,
+    required TResult Function(String name, Area area) areaChanged,
+    required TResult Function(String name) currentAreaChanged,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetCreated,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetUpdated,
+    required TResult Function(String name) exportPresetRemoved,
+    required TResult Function(NoteData pack) packAdded,
+    required TResult Function(String name, NoteData pack) packUpdated,
+    required TResult Function(String name) packRemoved,
+    required TResult Function(AnimationTrack animation) animationAdded,
+    required TResult Function(String name, AnimationTrack animation)
+        animationUpdated,
+    required TResult Function(String name) animationRemoved,
+    required TResult Function(AnimationTrack track, bool fullScreen)
+        presentationModeEntered,
+    required TResult Function() presentationModeExited,
+    required TResult Function(int tick) presentationTick,
+  }) {
+    return pageReordered(page, newIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
+    TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult? Function(ViewOption view)? viewChanged,
+    TResult? Function(UtilitiesState state)? utilitiesChanged,
+    TResult? Function(List<PadElement> elements)? elementsCreated,
+    TResult? Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult? Function(List<int> elements)? elementsRemoved,
+    TResult? Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult? Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult? Function(String path)? documentPathChanged,
+    TResult? Function(AssetLocation? location)? documentSaved,
+    TResult? Function(Tool tool)? toolCreated,
+    TResult? Function(Map<int, Tool> tools)? toolsChanged,
+    TResult? Function(List<int> tools)? toolsRemoved,
+    TResult? Function(int oldIndex, int newIndex)? toolReordered,
+    TResult? Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult? Function(Waypoint waypoint)? waypointCreated,
+    TResult? Function(int index, String name)? waypointRenamed,
+    TResult? Function(int index)? waypointRemoved,
+    TResult? Function(String oldName, String newName)? layerRenamed,
+    TResult? Function(String name)? layerRemoved,
+    TResult? Function(String name)? layerElementsRemoved,
+    TResult? Function(String name)? layerVisibilityChanged,
+    TResult? Function(String name)? currentLayerChanged,
+    TResult? Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult? Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult? Function(List<Area> areas)? areasCreated,
+    TResult? Function(List<String> areas)? areasRemoved,
+    TResult? Function(String name, Area area)? areaChanged,
+    TResult? Function(String name)? currentAreaChanged,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult? Function(String name)? exportPresetRemoved,
+    TResult? Function(NoteData pack)? packAdded,
+    TResult? Function(String name, NoteData pack)? packUpdated,
+    TResult? Function(String name)? packRemoved,
+    TResult? Function(AnimationTrack animation)? animationAdded,
+    TResult? Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult? Function(String name)? animationRemoved,
+    TResult? Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult? Function()? presentationModeExited,
+    TResult? Function(int tick)? presentationTick,
+  }) {
+    return pageReordered?.call(page, newIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
+    TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult Function(ViewOption view)? viewChanged,
+    TResult Function(UtilitiesState state)? utilitiesChanged,
+    TResult Function(List<PadElement> elements)? elementsCreated,
+    TResult Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult Function(List<int> elements)? elementsRemoved,
+    TResult Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult Function(String path)? documentPathChanged,
+    TResult Function(AssetLocation? location)? documentSaved,
+    TResult Function(Tool tool)? toolCreated,
+    TResult Function(Map<int, Tool> tools)? toolsChanged,
+    TResult Function(List<int> tools)? toolsRemoved,
+    TResult Function(int oldIndex, int newIndex)? toolReordered,
+    TResult Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult Function(Waypoint waypoint)? waypointCreated,
+    TResult Function(int index, String name)? waypointRenamed,
+    TResult Function(int index)? waypointRemoved,
+    TResult Function(String oldName, String newName)? layerRenamed,
+    TResult Function(String name)? layerRemoved,
+    TResult Function(String name)? layerElementsRemoved,
+    TResult Function(String name)? layerVisibilityChanged,
+    TResult Function(String name)? currentLayerChanged,
+    TResult Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult Function(List<Area> areas)? areasCreated,
+    TResult Function(List<String> areas)? areasRemoved,
+    TResult Function(String name, Area area)? areaChanged,
+    TResult Function(String name)? currentAreaChanged,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult Function(String name)? exportPresetRemoved,
+    TResult Function(NoteData pack)? packAdded,
+    TResult Function(String name, NoteData pack)? packUpdated,
+    TResult Function(String name)? packRemoved,
+    TResult Function(AnimationTrack animation)? animationAdded,
+    TResult Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult Function(String name)? animationRemoved,
+    TResult Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult Function()? presentationModeExited,
+    TResult Function(int tick)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (pageReordered != null) {
+      return pageReordered(page, newIndex);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
+    required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
+    required TResult Function(ViewChanged value) viewChanged,
+    required TResult Function(UtilitiesChanged value) utilitiesChanged,
+    required TResult Function(ElementsCreated value) elementsCreated,
+    required TResult Function(ElementsChanged value) elementsChanged,
+    required TResult Function(ElementsRemoved value) elementsRemoved,
+    required TResult Function(ElementsArranged value) elementsArranged,
+    required TResult Function(DocumentDescriptionChanged value)
+        documentDescriptionChanged,
+    required TResult Function(DocumentPathChanged value) documentPathChanged,
+    required TResult Function(DocumentSaved value) documentSaved,
+    required TResult Function(ToolCreated value) toolCreated,
+    required TResult Function(ToolsChanged value) toolsChanged,
+    required TResult Function(ToolsRemoved value) toolsRemoved,
+    required TResult Function(ToolReordered value) toolReordered,
+    required TResult Function(DocumentBackgroundsChanged value)
+        documentBackgroundsChanged,
+    required TResult Function(WaypointCreated value) waypointCreated,
+    required TResult Function(WaypointRenamed value) waypointRenamed,
+    required TResult Function(WaypointRemoved value) waypointRemoved,
+    required TResult Function(LayerRenamed value) layerRenamed,
+    required TResult Function(LayerRemoved value) layerRemoved,
+    required TResult Function(LayerElementsRemoved value) layerElementsRemoved,
+    required TResult Function(LayerVisibilityChanged value)
+        layerVisibilityChanged,
+    required TResult Function(CurrentLayerChanged value) currentLayerChanged,
+    required TResult Function(ElementsLayerChanged value) elementsLayerChanged,
+    required TResult Function(TemplateCreated value) templateCreated,
+    required TResult Function(AreasCreated value) areasCreated,
+    required TResult Function(AreasRemoved value) areasRemoved,
+    required TResult Function(AreaChanged value) areaChanged,
+    required TResult Function(CurrentAreaChanged value) currentAreaChanged,
+    required TResult Function(ExportPresetCreated value) exportPresetCreated,
+    required TResult Function(ExportPresetUpdated value) exportPresetUpdated,
+    required TResult Function(ExportPresetRemoved value) exportPresetRemoved,
+    required TResult Function(PackAdded value) packAdded,
+    required TResult Function(PackUpdated value) packUpdated,
+    required TResult Function(PackRemoved value) packRemoved,
+    required TResult Function(AnimationAdded value) animationAdded,
+    required TResult Function(AnimationUpdated value) animationUpdated,
+    required TResult Function(AnimationRemoved value) animationRemoved,
+    required TResult Function(PresentationModeEntered value)
+        presentationModeEntered,
+    required TResult Function(PresentationModeExited value)
+        presentationModeExited,
+    required TResult Function(PresentationTick value) presentationTick,
+  }) {
+    return pageReordered(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
+    TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult? Function(ViewChanged value)? viewChanged,
+    TResult? Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult? Function(ElementsCreated value)? elementsCreated,
+    TResult? Function(ElementsChanged value)? elementsChanged,
+    TResult? Function(ElementsRemoved value)? elementsRemoved,
+    TResult? Function(ElementsArranged value)? elementsArranged,
+    TResult? Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult? Function(DocumentPathChanged value)? documentPathChanged,
+    TResult? Function(DocumentSaved value)? documentSaved,
+    TResult? Function(ToolCreated value)? toolCreated,
+    TResult? Function(ToolsChanged value)? toolsChanged,
+    TResult? Function(ToolsRemoved value)? toolsRemoved,
+    TResult? Function(ToolReordered value)? toolReordered,
+    TResult? Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult? Function(WaypointCreated value)? waypointCreated,
+    TResult? Function(WaypointRenamed value)? waypointRenamed,
+    TResult? Function(WaypointRemoved value)? waypointRemoved,
+    TResult? Function(LayerRenamed value)? layerRenamed,
+    TResult? Function(LayerRemoved value)? layerRemoved,
+    TResult? Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult? Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult? Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult? Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult? Function(TemplateCreated value)? templateCreated,
+    TResult? Function(AreasCreated value)? areasCreated,
+    TResult? Function(AreasRemoved value)? areasRemoved,
+    TResult? Function(AreaChanged value)? areaChanged,
+    TResult? Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult? Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult? Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult? Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult? Function(PackAdded value)? packAdded,
+    TResult? Function(PackUpdated value)? packUpdated,
+    TResult? Function(PackRemoved value)? packRemoved,
+    TResult? Function(AnimationAdded value)? animationAdded,
+    TResult? Function(AnimationUpdated value)? animationUpdated,
+    TResult? Function(AnimationRemoved value)? animationRemoved,
+    TResult? Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult? Function(PresentationModeExited value)? presentationModeExited,
+    TResult? Function(PresentationTick value)? presentationTick,
+  }) {
+    return pageReordered?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
+    TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult Function(ViewChanged value)? viewChanged,
+    TResult Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult Function(ElementsCreated value)? elementsCreated,
+    TResult Function(ElementsChanged value)? elementsChanged,
+    TResult Function(ElementsRemoved value)? elementsRemoved,
+    TResult Function(ElementsArranged value)? elementsArranged,
+    TResult Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult Function(DocumentPathChanged value)? documentPathChanged,
+    TResult Function(DocumentSaved value)? documentSaved,
+    TResult Function(ToolCreated value)? toolCreated,
+    TResult Function(ToolsChanged value)? toolsChanged,
+    TResult Function(ToolsRemoved value)? toolsRemoved,
+    TResult Function(ToolReordered value)? toolReordered,
+    TResult Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult Function(WaypointCreated value)? waypointCreated,
+    TResult Function(WaypointRenamed value)? waypointRenamed,
+    TResult Function(WaypointRemoved value)? waypointRemoved,
+    TResult Function(LayerRenamed value)? layerRenamed,
+    TResult Function(LayerRemoved value)? layerRemoved,
+    TResult Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult Function(TemplateCreated value)? templateCreated,
+    TResult Function(AreasCreated value)? areasCreated,
+    TResult Function(AreasRemoved value)? areasRemoved,
+    TResult Function(AreaChanged value)? areaChanged,
+    TResult Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult Function(PackAdded value)? packAdded,
+    TResult Function(PackUpdated value)? packUpdated,
+    TResult Function(PackRemoved value)? packRemoved,
+    TResult Function(AnimationAdded value)? animationAdded,
+    TResult Function(AnimationUpdated value)? animationUpdated,
+    TResult Function(AnimationRemoved value)? animationRemoved,
+    TResult Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult Function(PresentationModeExited value)? presentationModeExited,
+    TResult Function(PresentationTick value)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (pageReordered != null) {
+      return pageReordered(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PageReorderedToJson(
+      this,
+    );
+  }
+}
+
+abstract class PageReordered extends DocumentEvent {
+  const factory PageReordered(final String page, [final int? newIndex]) =
+      _$PageReordered;
+  const PageReordered._() : super._();
+
+  factory PageReordered.fromJson(Map<String, dynamic> json) =
+      _$PageReordered.fromJson;
+
+  String get page;
+  int? get newIndex;
+  @JsonKey(ignore: true)
+  _$$PageReorderedCopyWith<_$PageReordered> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PageRenamedCopyWith<$Res> {
+  factory _$$PageRenamedCopyWith(
+          _$PageRenamed value, $Res Function(_$PageRenamed) then) =
+      __$$PageRenamedCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String oldName, String newName});
+}
+
+/// @nodoc
+class __$$PageRenamedCopyWithImpl<$Res>
+    extends _$DocumentEventCopyWithImpl<$Res, _$PageRenamed>
+    implements _$$PageRenamedCopyWith<$Res> {
+  __$$PageRenamedCopyWithImpl(
+      _$PageRenamed _value, $Res Function(_$PageRenamed) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? oldName = null,
+    Object? newName = null,
+  }) {
+    return _then(_$PageRenamed(
+      null == oldName
+          ? _value.oldName
+          : oldName // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == newName
+          ? _value.newName
+          : newName // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PageRenamed extends PageRenamed {
+  const _$PageRenamed(this.oldName, this.newName, {final String? $type})
+      : $type = $type ?? 'pageRenamed',
+        super._();
+
+  factory _$PageRenamed.fromJson(Map<String, dynamic> json) =>
+      _$$PageRenamedFromJson(json);
+
+  @override
+  final String oldName;
+  @override
+  final String newName;
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'DocumentEvent.pageRenamed(oldName: $oldName, newName: $newName)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageRenamed &&
+            (identical(other.oldName, oldName) || other.oldName == oldName) &&
+            (identical(other.newName, newName) || other.newName == newName));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, oldName, newName);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageRenamedCopyWith<_$PageRenamed> get copyWith =>
+      __$$PageRenamedCopyWithImpl<_$PageRenamed>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
+    required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
+    required TResult Function(ViewOption view) viewChanged,
+    required TResult Function(UtilitiesState state) utilitiesChanged,
+    required TResult Function(List<PadElement> elements) elementsCreated,
+    required TResult Function(Map<int, List<PadElement>> elements)
+        elementsChanged,
+    required TResult Function(List<int> elements) elementsRemoved,
+    required TResult Function(Arrangement arrangement, List<int> elements)
+        elementsArranged,
+    required TResult Function(String? name, String? description)
+        documentDescriptionChanged,
+    required TResult Function(String path) documentPathChanged,
+    required TResult Function(AssetLocation? location) documentSaved,
+    required TResult Function(Tool tool) toolCreated,
+    required TResult Function(Map<int, Tool> tools) toolsChanged,
+    required TResult Function(List<int> tools) toolsRemoved,
+    required TResult Function(int oldIndex, int newIndex) toolReordered,
+    required TResult Function(List<Background> backgrounds)
+        documentBackgroundsChanged,
+    required TResult Function(Waypoint waypoint) waypointCreated,
+    required TResult Function(int index, String name) waypointRenamed,
+    required TResult Function(int index) waypointRemoved,
+    required TResult Function(String oldName, String newName) layerRenamed,
+    required TResult Function(String name) layerRemoved,
+    required TResult Function(String name) layerElementsRemoved,
+    required TResult Function(String name) layerVisibilityChanged,
+    required TResult Function(String name) currentLayerChanged,
+    required TResult Function(String layer, List<int> elements)
+        elementsLayerChanged,
+    required TResult Function(
+            String directory, String? remote, bool deleteDocument)
+        templateCreated,
+    required TResult Function(List<Area> areas) areasCreated,
+    required TResult Function(List<String> areas) areasRemoved,
+    required TResult Function(String name, Area area) areaChanged,
+    required TResult Function(String name) currentAreaChanged,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetCreated,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetUpdated,
+    required TResult Function(String name) exportPresetRemoved,
+    required TResult Function(NoteData pack) packAdded,
+    required TResult Function(String name, NoteData pack) packUpdated,
+    required TResult Function(String name) packRemoved,
+    required TResult Function(AnimationTrack animation) animationAdded,
+    required TResult Function(String name, AnimationTrack animation)
+        animationUpdated,
+    required TResult Function(String name) animationRemoved,
+    required TResult Function(AnimationTrack track, bool fullScreen)
+        presentationModeEntered,
+    required TResult Function() presentationModeExited,
+    required TResult Function(int tick) presentationTick,
+  }) {
+    return pageRenamed(oldName, newName);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
+    TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult? Function(ViewOption view)? viewChanged,
+    TResult? Function(UtilitiesState state)? utilitiesChanged,
+    TResult? Function(List<PadElement> elements)? elementsCreated,
+    TResult? Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult? Function(List<int> elements)? elementsRemoved,
+    TResult? Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult? Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult? Function(String path)? documentPathChanged,
+    TResult? Function(AssetLocation? location)? documentSaved,
+    TResult? Function(Tool tool)? toolCreated,
+    TResult? Function(Map<int, Tool> tools)? toolsChanged,
+    TResult? Function(List<int> tools)? toolsRemoved,
+    TResult? Function(int oldIndex, int newIndex)? toolReordered,
+    TResult? Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult? Function(Waypoint waypoint)? waypointCreated,
+    TResult? Function(int index, String name)? waypointRenamed,
+    TResult? Function(int index)? waypointRemoved,
+    TResult? Function(String oldName, String newName)? layerRenamed,
+    TResult? Function(String name)? layerRemoved,
+    TResult? Function(String name)? layerElementsRemoved,
+    TResult? Function(String name)? layerVisibilityChanged,
+    TResult? Function(String name)? currentLayerChanged,
+    TResult? Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult? Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult? Function(List<Area> areas)? areasCreated,
+    TResult? Function(List<String> areas)? areasRemoved,
+    TResult? Function(String name, Area area)? areaChanged,
+    TResult? Function(String name)? currentAreaChanged,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult? Function(String name)? exportPresetRemoved,
+    TResult? Function(NoteData pack)? packAdded,
+    TResult? Function(String name, NoteData pack)? packUpdated,
+    TResult? Function(String name)? packRemoved,
+    TResult? Function(AnimationTrack animation)? animationAdded,
+    TResult? Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult? Function(String name)? animationRemoved,
+    TResult? Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult? Function()? presentationModeExited,
+    TResult? Function(int tick)? presentationTick,
+  }) {
+    return pageRenamed?.call(oldName, newName);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
+    TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult Function(ViewOption view)? viewChanged,
+    TResult Function(UtilitiesState state)? utilitiesChanged,
+    TResult Function(List<PadElement> elements)? elementsCreated,
+    TResult Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult Function(List<int> elements)? elementsRemoved,
+    TResult Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult Function(String path)? documentPathChanged,
+    TResult Function(AssetLocation? location)? documentSaved,
+    TResult Function(Tool tool)? toolCreated,
+    TResult Function(Map<int, Tool> tools)? toolsChanged,
+    TResult Function(List<int> tools)? toolsRemoved,
+    TResult Function(int oldIndex, int newIndex)? toolReordered,
+    TResult Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult Function(Waypoint waypoint)? waypointCreated,
+    TResult Function(int index, String name)? waypointRenamed,
+    TResult Function(int index)? waypointRemoved,
+    TResult Function(String oldName, String newName)? layerRenamed,
+    TResult Function(String name)? layerRemoved,
+    TResult Function(String name)? layerElementsRemoved,
+    TResult Function(String name)? layerVisibilityChanged,
+    TResult Function(String name)? currentLayerChanged,
+    TResult Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult Function(List<Area> areas)? areasCreated,
+    TResult Function(List<String> areas)? areasRemoved,
+    TResult Function(String name, Area area)? areaChanged,
+    TResult Function(String name)? currentAreaChanged,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult Function(String name)? exportPresetRemoved,
+    TResult Function(NoteData pack)? packAdded,
+    TResult Function(String name, NoteData pack)? packUpdated,
+    TResult Function(String name)? packRemoved,
+    TResult Function(AnimationTrack animation)? animationAdded,
+    TResult Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult Function(String name)? animationRemoved,
+    TResult Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult Function()? presentationModeExited,
+    TResult Function(int tick)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (pageRenamed != null) {
+      return pageRenamed(oldName, newName);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
+    required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
+    required TResult Function(ViewChanged value) viewChanged,
+    required TResult Function(UtilitiesChanged value) utilitiesChanged,
+    required TResult Function(ElementsCreated value) elementsCreated,
+    required TResult Function(ElementsChanged value) elementsChanged,
+    required TResult Function(ElementsRemoved value) elementsRemoved,
+    required TResult Function(ElementsArranged value) elementsArranged,
+    required TResult Function(DocumentDescriptionChanged value)
+        documentDescriptionChanged,
+    required TResult Function(DocumentPathChanged value) documentPathChanged,
+    required TResult Function(DocumentSaved value) documentSaved,
+    required TResult Function(ToolCreated value) toolCreated,
+    required TResult Function(ToolsChanged value) toolsChanged,
+    required TResult Function(ToolsRemoved value) toolsRemoved,
+    required TResult Function(ToolReordered value) toolReordered,
+    required TResult Function(DocumentBackgroundsChanged value)
+        documentBackgroundsChanged,
+    required TResult Function(WaypointCreated value) waypointCreated,
+    required TResult Function(WaypointRenamed value) waypointRenamed,
+    required TResult Function(WaypointRemoved value) waypointRemoved,
+    required TResult Function(LayerRenamed value) layerRenamed,
+    required TResult Function(LayerRemoved value) layerRemoved,
+    required TResult Function(LayerElementsRemoved value) layerElementsRemoved,
+    required TResult Function(LayerVisibilityChanged value)
+        layerVisibilityChanged,
+    required TResult Function(CurrentLayerChanged value) currentLayerChanged,
+    required TResult Function(ElementsLayerChanged value) elementsLayerChanged,
+    required TResult Function(TemplateCreated value) templateCreated,
+    required TResult Function(AreasCreated value) areasCreated,
+    required TResult Function(AreasRemoved value) areasRemoved,
+    required TResult Function(AreaChanged value) areaChanged,
+    required TResult Function(CurrentAreaChanged value) currentAreaChanged,
+    required TResult Function(ExportPresetCreated value) exportPresetCreated,
+    required TResult Function(ExportPresetUpdated value) exportPresetUpdated,
+    required TResult Function(ExportPresetRemoved value) exportPresetRemoved,
+    required TResult Function(PackAdded value) packAdded,
+    required TResult Function(PackUpdated value) packUpdated,
+    required TResult Function(PackRemoved value) packRemoved,
+    required TResult Function(AnimationAdded value) animationAdded,
+    required TResult Function(AnimationUpdated value) animationUpdated,
+    required TResult Function(AnimationRemoved value) animationRemoved,
+    required TResult Function(PresentationModeEntered value)
+        presentationModeEntered,
+    required TResult Function(PresentationModeExited value)
+        presentationModeExited,
+    required TResult Function(PresentationTick value) presentationTick,
+  }) {
+    return pageRenamed(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
+    TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult? Function(ViewChanged value)? viewChanged,
+    TResult? Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult? Function(ElementsCreated value)? elementsCreated,
+    TResult? Function(ElementsChanged value)? elementsChanged,
+    TResult? Function(ElementsRemoved value)? elementsRemoved,
+    TResult? Function(ElementsArranged value)? elementsArranged,
+    TResult? Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult? Function(DocumentPathChanged value)? documentPathChanged,
+    TResult? Function(DocumentSaved value)? documentSaved,
+    TResult? Function(ToolCreated value)? toolCreated,
+    TResult? Function(ToolsChanged value)? toolsChanged,
+    TResult? Function(ToolsRemoved value)? toolsRemoved,
+    TResult? Function(ToolReordered value)? toolReordered,
+    TResult? Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult? Function(WaypointCreated value)? waypointCreated,
+    TResult? Function(WaypointRenamed value)? waypointRenamed,
+    TResult? Function(WaypointRemoved value)? waypointRemoved,
+    TResult? Function(LayerRenamed value)? layerRenamed,
+    TResult? Function(LayerRemoved value)? layerRemoved,
+    TResult? Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult? Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult? Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult? Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult? Function(TemplateCreated value)? templateCreated,
+    TResult? Function(AreasCreated value)? areasCreated,
+    TResult? Function(AreasRemoved value)? areasRemoved,
+    TResult? Function(AreaChanged value)? areaChanged,
+    TResult? Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult? Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult? Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult? Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult? Function(PackAdded value)? packAdded,
+    TResult? Function(PackUpdated value)? packUpdated,
+    TResult? Function(PackRemoved value)? packRemoved,
+    TResult? Function(AnimationAdded value)? animationAdded,
+    TResult? Function(AnimationUpdated value)? animationUpdated,
+    TResult? Function(AnimationRemoved value)? animationRemoved,
+    TResult? Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult? Function(PresentationModeExited value)? presentationModeExited,
+    TResult? Function(PresentationTick value)? presentationTick,
+  }) {
+    return pageRenamed?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
+    TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult Function(ViewChanged value)? viewChanged,
+    TResult Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult Function(ElementsCreated value)? elementsCreated,
+    TResult Function(ElementsChanged value)? elementsChanged,
+    TResult Function(ElementsRemoved value)? elementsRemoved,
+    TResult Function(ElementsArranged value)? elementsArranged,
+    TResult Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult Function(DocumentPathChanged value)? documentPathChanged,
+    TResult Function(DocumentSaved value)? documentSaved,
+    TResult Function(ToolCreated value)? toolCreated,
+    TResult Function(ToolsChanged value)? toolsChanged,
+    TResult Function(ToolsRemoved value)? toolsRemoved,
+    TResult Function(ToolReordered value)? toolReordered,
+    TResult Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult Function(WaypointCreated value)? waypointCreated,
+    TResult Function(WaypointRenamed value)? waypointRenamed,
+    TResult Function(WaypointRemoved value)? waypointRemoved,
+    TResult Function(LayerRenamed value)? layerRenamed,
+    TResult Function(LayerRemoved value)? layerRemoved,
+    TResult Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult Function(TemplateCreated value)? templateCreated,
+    TResult Function(AreasCreated value)? areasCreated,
+    TResult Function(AreasRemoved value)? areasRemoved,
+    TResult Function(AreaChanged value)? areaChanged,
+    TResult Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult Function(PackAdded value)? packAdded,
+    TResult Function(PackUpdated value)? packUpdated,
+    TResult Function(PackRemoved value)? packRemoved,
+    TResult Function(AnimationAdded value)? animationAdded,
+    TResult Function(AnimationUpdated value)? animationUpdated,
+    TResult Function(AnimationRemoved value)? animationRemoved,
+    TResult Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult Function(PresentationModeExited value)? presentationModeExited,
+    TResult Function(PresentationTick value)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (pageRenamed != null) {
+      return pageRenamed(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PageRenamedToJson(
+      this,
+    );
+  }
+}
+
+abstract class PageRenamed extends DocumentEvent {
+  const factory PageRenamed(final String oldName, final String newName) =
+      _$PageRenamed;
+  const PageRenamed._() : super._();
+
+  factory PageRenamed.fromJson(Map<String, dynamic> json) =
+      _$PageRenamed.fromJson;
+
+  String get oldName;
+  String get newName;
+  @JsonKey(ignore: true)
+  _$$PageRenamedCopyWith<_$PageRenamed> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PageRemovedCopyWith<$Res> {
+  factory _$$PageRemovedCopyWith(
+          _$PageRemoved value, $Res Function(_$PageRemoved) then) =
+      __$$PageRemovedCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String page});
+}
+
+/// @nodoc
+class __$$PageRemovedCopyWithImpl<$Res>
+    extends _$DocumentEventCopyWithImpl<$Res, _$PageRemoved>
+    implements _$$PageRemovedCopyWith<$Res> {
+  __$$PageRemovedCopyWithImpl(
+      _$PageRemoved _value, $Res Function(_$PageRemoved) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? page = null,
+  }) {
+    return _then(_$PageRemoved(
+      null == page
+          ? _value.page
+          : page // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PageRemoved extends PageRemoved {
+  const _$PageRemoved(this.page, {final String? $type})
+      : $type = $type ?? 'pageRemoved',
+        super._();
+
+  factory _$PageRemoved.fromJson(Map<String, dynamic> json) =>
+      _$$PageRemovedFromJson(json);
+
+  @override
+  final String page;
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'DocumentEvent.pageRemoved(page: $page)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageRemoved &&
+            (identical(other.page, page) || other.page == page));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, page);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageRemovedCopyWith<_$PageRemoved> get copyWith =>
+      __$$PageRemovedCopyWithImpl<_$PageRemoved>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
+    required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
+    required TResult Function(ViewOption view) viewChanged,
+    required TResult Function(UtilitiesState state) utilitiesChanged,
+    required TResult Function(List<PadElement> elements) elementsCreated,
+    required TResult Function(Map<int, List<PadElement>> elements)
+        elementsChanged,
+    required TResult Function(List<int> elements) elementsRemoved,
+    required TResult Function(Arrangement arrangement, List<int> elements)
+        elementsArranged,
+    required TResult Function(String? name, String? description)
+        documentDescriptionChanged,
+    required TResult Function(String path) documentPathChanged,
+    required TResult Function(AssetLocation? location) documentSaved,
+    required TResult Function(Tool tool) toolCreated,
+    required TResult Function(Map<int, Tool> tools) toolsChanged,
+    required TResult Function(List<int> tools) toolsRemoved,
+    required TResult Function(int oldIndex, int newIndex) toolReordered,
+    required TResult Function(List<Background> backgrounds)
+        documentBackgroundsChanged,
+    required TResult Function(Waypoint waypoint) waypointCreated,
+    required TResult Function(int index, String name) waypointRenamed,
+    required TResult Function(int index) waypointRemoved,
+    required TResult Function(String oldName, String newName) layerRenamed,
+    required TResult Function(String name) layerRemoved,
+    required TResult Function(String name) layerElementsRemoved,
+    required TResult Function(String name) layerVisibilityChanged,
+    required TResult Function(String name) currentLayerChanged,
+    required TResult Function(String layer, List<int> elements)
+        elementsLayerChanged,
+    required TResult Function(
+            String directory, String? remote, bool deleteDocument)
+        templateCreated,
+    required TResult Function(List<Area> areas) areasCreated,
+    required TResult Function(List<String> areas) areasRemoved,
+    required TResult Function(String name, Area area) areaChanged,
+    required TResult Function(String name) currentAreaChanged,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetCreated,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetUpdated,
+    required TResult Function(String name) exportPresetRemoved,
+    required TResult Function(NoteData pack) packAdded,
+    required TResult Function(String name, NoteData pack) packUpdated,
+    required TResult Function(String name) packRemoved,
+    required TResult Function(AnimationTrack animation) animationAdded,
+    required TResult Function(String name, AnimationTrack animation)
+        animationUpdated,
+    required TResult Function(String name) animationRemoved,
+    required TResult Function(AnimationTrack track, bool fullScreen)
+        presentationModeEntered,
+    required TResult Function() presentationModeExited,
+    required TResult Function(int tick) presentationTick,
+  }) {
+    return pageRemoved(page);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
+    TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult? Function(ViewOption view)? viewChanged,
+    TResult? Function(UtilitiesState state)? utilitiesChanged,
+    TResult? Function(List<PadElement> elements)? elementsCreated,
+    TResult? Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult? Function(List<int> elements)? elementsRemoved,
+    TResult? Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult? Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult? Function(String path)? documentPathChanged,
+    TResult? Function(AssetLocation? location)? documentSaved,
+    TResult? Function(Tool tool)? toolCreated,
+    TResult? Function(Map<int, Tool> tools)? toolsChanged,
+    TResult? Function(List<int> tools)? toolsRemoved,
+    TResult? Function(int oldIndex, int newIndex)? toolReordered,
+    TResult? Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult? Function(Waypoint waypoint)? waypointCreated,
+    TResult? Function(int index, String name)? waypointRenamed,
+    TResult? Function(int index)? waypointRemoved,
+    TResult? Function(String oldName, String newName)? layerRenamed,
+    TResult? Function(String name)? layerRemoved,
+    TResult? Function(String name)? layerElementsRemoved,
+    TResult? Function(String name)? layerVisibilityChanged,
+    TResult? Function(String name)? currentLayerChanged,
+    TResult? Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult? Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult? Function(List<Area> areas)? areasCreated,
+    TResult? Function(List<String> areas)? areasRemoved,
+    TResult? Function(String name, Area area)? areaChanged,
+    TResult? Function(String name)? currentAreaChanged,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult? Function(String name)? exportPresetRemoved,
+    TResult? Function(NoteData pack)? packAdded,
+    TResult? Function(String name, NoteData pack)? packUpdated,
+    TResult? Function(String name)? packRemoved,
+    TResult? Function(AnimationTrack animation)? animationAdded,
+    TResult? Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult? Function(String name)? animationRemoved,
+    TResult? Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult? Function()? presentationModeExited,
+    TResult? Function(int tick)? presentationTick,
+  }) {
+    return pageRemoved?.call(page);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
+    TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult Function(ViewOption view)? viewChanged,
+    TResult Function(UtilitiesState state)? utilitiesChanged,
+    TResult Function(List<PadElement> elements)? elementsCreated,
+    TResult Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult Function(List<int> elements)? elementsRemoved,
+    TResult Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult Function(String path)? documentPathChanged,
+    TResult Function(AssetLocation? location)? documentSaved,
+    TResult Function(Tool tool)? toolCreated,
+    TResult Function(Map<int, Tool> tools)? toolsChanged,
+    TResult Function(List<int> tools)? toolsRemoved,
+    TResult Function(int oldIndex, int newIndex)? toolReordered,
+    TResult Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult Function(Waypoint waypoint)? waypointCreated,
+    TResult Function(int index, String name)? waypointRenamed,
+    TResult Function(int index)? waypointRemoved,
+    TResult Function(String oldName, String newName)? layerRenamed,
+    TResult Function(String name)? layerRemoved,
+    TResult Function(String name)? layerElementsRemoved,
+    TResult Function(String name)? layerVisibilityChanged,
+    TResult Function(String name)? currentLayerChanged,
+    TResult Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult Function(List<Area> areas)? areasCreated,
+    TResult Function(List<String> areas)? areasRemoved,
+    TResult Function(String name, Area area)? areaChanged,
+    TResult Function(String name)? currentAreaChanged,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult Function(String name)? exportPresetRemoved,
+    TResult Function(NoteData pack)? packAdded,
+    TResult Function(String name, NoteData pack)? packUpdated,
+    TResult Function(String name)? packRemoved,
+    TResult Function(AnimationTrack animation)? animationAdded,
+    TResult Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult Function(String name)? animationRemoved,
+    TResult Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult Function()? presentationModeExited,
+    TResult Function(int tick)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (pageRemoved != null) {
+      return pageRemoved(page);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
+    required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
+    required TResult Function(ViewChanged value) viewChanged,
+    required TResult Function(UtilitiesChanged value) utilitiesChanged,
+    required TResult Function(ElementsCreated value) elementsCreated,
+    required TResult Function(ElementsChanged value) elementsChanged,
+    required TResult Function(ElementsRemoved value) elementsRemoved,
+    required TResult Function(ElementsArranged value) elementsArranged,
+    required TResult Function(DocumentDescriptionChanged value)
+        documentDescriptionChanged,
+    required TResult Function(DocumentPathChanged value) documentPathChanged,
+    required TResult Function(DocumentSaved value) documentSaved,
+    required TResult Function(ToolCreated value) toolCreated,
+    required TResult Function(ToolsChanged value) toolsChanged,
+    required TResult Function(ToolsRemoved value) toolsRemoved,
+    required TResult Function(ToolReordered value) toolReordered,
+    required TResult Function(DocumentBackgroundsChanged value)
+        documentBackgroundsChanged,
+    required TResult Function(WaypointCreated value) waypointCreated,
+    required TResult Function(WaypointRenamed value) waypointRenamed,
+    required TResult Function(WaypointRemoved value) waypointRemoved,
+    required TResult Function(LayerRenamed value) layerRenamed,
+    required TResult Function(LayerRemoved value) layerRemoved,
+    required TResult Function(LayerElementsRemoved value) layerElementsRemoved,
+    required TResult Function(LayerVisibilityChanged value)
+        layerVisibilityChanged,
+    required TResult Function(CurrentLayerChanged value) currentLayerChanged,
+    required TResult Function(ElementsLayerChanged value) elementsLayerChanged,
+    required TResult Function(TemplateCreated value) templateCreated,
+    required TResult Function(AreasCreated value) areasCreated,
+    required TResult Function(AreasRemoved value) areasRemoved,
+    required TResult Function(AreaChanged value) areaChanged,
+    required TResult Function(CurrentAreaChanged value) currentAreaChanged,
+    required TResult Function(ExportPresetCreated value) exportPresetCreated,
+    required TResult Function(ExportPresetUpdated value) exportPresetUpdated,
+    required TResult Function(ExportPresetRemoved value) exportPresetRemoved,
+    required TResult Function(PackAdded value) packAdded,
+    required TResult Function(PackUpdated value) packUpdated,
+    required TResult Function(PackRemoved value) packRemoved,
+    required TResult Function(AnimationAdded value) animationAdded,
+    required TResult Function(AnimationUpdated value) animationUpdated,
+    required TResult Function(AnimationRemoved value) animationRemoved,
+    required TResult Function(PresentationModeEntered value)
+        presentationModeEntered,
+    required TResult Function(PresentationModeExited value)
+        presentationModeExited,
+    required TResult Function(PresentationTick value) presentationTick,
+  }) {
+    return pageRemoved(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
+    TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult? Function(ViewChanged value)? viewChanged,
+    TResult? Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult? Function(ElementsCreated value)? elementsCreated,
+    TResult? Function(ElementsChanged value)? elementsChanged,
+    TResult? Function(ElementsRemoved value)? elementsRemoved,
+    TResult? Function(ElementsArranged value)? elementsArranged,
+    TResult? Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult? Function(DocumentPathChanged value)? documentPathChanged,
+    TResult? Function(DocumentSaved value)? documentSaved,
+    TResult? Function(ToolCreated value)? toolCreated,
+    TResult? Function(ToolsChanged value)? toolsChanged,
+    TResult? Function(ToolsRemoved value)? toolsRemoved,
+    TResult? Function(ToolReordered value)? toolReordered,
+    TResult? Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult? Function(WaypointCreated value)? waypointCreated,
+    TResult? Function(WaypointRenamed value)? waypointRenamed,
+    TResult? Function(WaypointRemoved value)? waypointRemoved,
+    TResult? Function(LayerRenamed value)? layerRenamed,
+    TResult? Function(LayerRemoved value)? layerRemoved,
+    TResult? Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult? Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult? Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult? Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult? Function(TemplateCreated value)? templateCreated,
+    TResult? Function(AreasCreated value)? areasCreated,
+    TResult? Function(AreasRemoved value)? areasRemoved,
+    TResult? Function(AreaChanged value)? areaChanged,
+    TResult? Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult? Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult? Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult? Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult? Function(PackAdded value)? packAdded,
+    TResult? Function(PackUpdated value)? packUpdated,
+    TResult? Function(PackRemoved value)? packRemoved,
+    TResult? Function(AnimationAdded value)? animationAdded,
+    TResult? Function(AnimationUpdated value)? animationUpdated,
+    TResult? Function(AnimationRemoved value)? animationRemoved,
+    TResult? Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult? Function(PresentationModeExited value)? presentationModeExited,
+    TResult? Function(PresentationTick value)? presentationTick,
+  }) {
+    return pageRemoved?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
+    TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult Function(ViewChanged value)? viewChanged,
+    TResult Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult Function(ElementsCreated value)? elementsCreated,
+    TResult Function(ElementsChanged value)? elementsChanged,
+    TResult Function(ElementsRemoved value)? elementsRemoved,
+    TResult Function(ElementsArranged value)? elementsArranged,
+    TResult Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult Function(DocumentPathChanged value)? documentPathChanged,
+    TResult Function(DocumentSaved value)? documentSaved,
+    TResult Function(ToolCreated value)? toolCreated,
+    TResult Function(ToolsChanged value)? toolsChanged,
+    TResult Function(ToolsRemoved value)? toolsRemoved,
+    TResult Function(ToolReordered value)? toolReordered,
+    TResult Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult Function(WaypointCreated value)? waypointCreated,
+    TResult Function(WaypointRenamed value)? waypointRenamed,
+    TResult Function(WaypointRemoved value)? waypointRemoved,
+    TResult Function(LayerRenamed value)? layerRenamed,
+    TResult Function(LayerRemoved value)? layerRemoved,
+    TResult Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult Function(TemplateCreated value)? templateCreated,
+    TResult Function(AreasCreated value)? areasCreated,
+    TResult Function(AreasRemoved value)? areasRemoved,
+    TResult Function(AreaChanged value)? areaChanged,
+    TResult Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult Function(PackAdded value)? packAdded,
+    TResult Function(PackUpdated value)? packUpdated,
+    TResult Function(PackRemoved value)? packRemoved,
+    TResult Function(AnimationAdded value)? animationAdded,
+    TResult Function(AnimationUpdated value)? animationUpdated,
+    TResult Function(AnimationRemoved value)? animationRemoved,
+    TResult Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult Function(PresentationModeExited value)? presentationModeExited,
+    TResult Function(PresentationTick value)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (pageRemoved != null) {
+      return pageRemoved(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PageRemovedToJson(
+      this,
+    );
+  }
+}
+
+abstract class PageRemoved extends DocumentEvent {
+  const factory PageRemoved(final String page) = _$PageRemoved;
+  const PageRemoved._() : super._();
+
+  factory PageRemoved.fromJson(Map<String, dynamic> json) =
+      _$PageRemoved.fromJson;
+
+  String get page;
+  @JsonKey(ignore: true)
+  _$$PageRemovedCopyWith<_$PageRemoved> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ThumbnailCapturedCopyWith<$Res> {
+  factory _$$ThumbnailCapturedCopyWith(
+          _$ThumbnailCaptured value, $Res Function(_$ThumbnailCaptured) then) =
+      __$$ThumbnailCapturedCopyWithImpl<$Res>;
+  @useResult
+  $Res call({@Uint8ListJsonConverter() Uint8List data});
+}
+
+/// @nodoc
+class __$$ThumbnailCapturedCopyWithImpl<$Res>
+    extends _$DocumentEventCopyWithImpl<$Res, _$ThumbnailCaptured>
+    implements _$$ThumbnailCapturedCopyWith<$Res> {
+  __$$ThumbnailCapturedCopyWithImpl(
+      _$ThumbnailCaptured _value, $Res Function(_$ThumbnailCaptured) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+  }) {
+    return _then(_$ThumbnailCaptured(
+      null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ThumbnailCaptured extends ThumbnailCaptured {
+  const _$ThumbnailCaptured(@Uint8ListJsonConverter() this.data,
+      {final String? $type})
+      : $type = $type ?? 'thumbnailCaptured',
+        super._();
+
+  factory _$ThumbnailCaptured.fromJson(Map<String, dynamic> json) =>
+      _$$ThumbnailCapturedFromJson(json);
+
+  @override
+  @Uint8ListJsonConverter()
+  final Uint8List data;
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'DocumentEvent.thumbnailCaptured(data: $data)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ThumbnailCaptured &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(data));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ThumbnailCapturedCopyWith<_$ThumbnailCaptured> get copyWith =>
+      __$$ThumbnailCapturedCopyWithImpl<_$ThumbnailCaptured>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
+    required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
+    required TResult Function(ViewOption view) viewChanged,
+    required TResult Function(UtilitiesState state) utilitiesChanged,
+    required TResult Function(List<PadElement> elements) elementsCreated,
+    required TResult Function(Map<int, List<PadElement>> elements)
+        elementsChanged,
+    required TResult Function(List<int> elements) elementsRemoved,
+    required TResult Function(Arrangement arrangement, List<int> elements)
+        elementsArranged,
+    required TResult Function(String? name, String? description)
+        documentDescriptionChanged,
+    required TResult Function(String path) documentPathChanged,
+    required TResult Function(AssetLocation? location) documentSaved,
+    required TResult Function(Tool tool) toolCreated,
+    required TResult Function(Map<int, Tool> tools) toolsChanged,
+    required TResult Function(List<int> tools) toolsRemoved,
+    required TResult Function(int oldIndex, int newIndex) toolReordered,
+    required TResult Function(List<Background> backgrounds)
+        documentBackgroundsChanged,
+    required TResult Function(Waypoint waypoint) waypointCreated,
+    required TResult Function(int index, String name) waypointRenamed,
+    required TResult Function(int index) waypointRemoved,
+    required TResult Function(String oldName, String newName) layerRenamed,
+    required TResult Function(String name) layerRemoved,
+    required TResult Function(String name) layerElementsRemoved,
+    required TResult Function(String name) layerVisibilityChanged,
+    required TResult Function(String name) currentLayerChanged,
+    required TResult Function(String layer, List<int> elements)
+        elementsLayerChanged,
+    required TResult Function(
+            String directory, String? remote, bool deleteDocument)
+        templateCreated,
+    required TResult Function(List<Area> areas) areasCreated,
+    required TResult Function(List<String> areas) areasRemoved,
+    required TResult Function(String name, Area area) areaChanged,
+    required TResult Function(String name) currentAreaChanged,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetCreated,
+    required TResult Function(String name, List<AreaPreset> areas)
+        exportPresetUpdated,
+    required TResult Function(String name) exportPresetRemoved,
+    required TResult Function(NoteData pack) packAdded,
+    required TResult Function(String name, NoteData pack) packUpdated,
+    required TResult Function(String name) packRemoved,
+    required TResult Function(AnimationTrack animation) animationAdded,
+    required TResult Function(String name, AnimationTrack animation)
+        animationUpdated,
+    required TResult Function(String name) animationRemoved,
+    required TResult Function(AnimationTrack track, bool fullScreen)
+        presentationModeEntered,
+    required TResult Function() presentationModeExited,
+    required TResult Function(int tick) presentationTick,
+  }) {
+    return thumbnailCaptured(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
+    TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult? Function(ViewOption view)? viewChanged,
+    TResult? Function(UtilitiesState state)? utilitiesChanged,
+    TResult? Function(List<PadElement> elements)? elementsCreated,
+    TResult? Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult? Function(List<int> elements)? elementsRemoved,
+    TResult? Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult? Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult? Function(String path)? documentPathChanged,
+    TResult? Function(AssetLocation? location)? documentSaved,
+    TResult? Function(Tool tool)? toolCreated,
+    TResult? Function(Map<int, Tool> tools)? toolsChanged,
+    TResult? Function(List<int> tools)? toolsRemoved,
+    TResult? Function(int oldIndex, int newIndex)? toolReordered,
+    TResult? Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult? Function(Waypoint waypoint)? waypointCreated,
+    TResult? Function(int index, String name)? waypointRenamed,
+    TResult? Function(int index)? waypointRemoved,
+    TResult? Function(String oldName, String newName)? layerRenamed,
+    TResult? Function(String name)? layerRemoved,
+    TResult? Function(String name)? layerElementsRemoved,
+    TResult? Function(String name)? layerVisibilityChanged,
+    TResult? Function(String name)? currentLayerChanged,
+    TResult? Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult? Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult? Function(List<Area> areas)? areasCreated,
+    TResult? Function(List<String> areas)? areasRemoved,
+    TResult? Function(String name, Area area)? areaChanged,
+    TResult? Function(String name)? currentAreaChanged,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult? Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult? Function(String name)? exportPresetRemoved,
+    TResult? Function(NoteData pack)? packAdded,
+    TResult? Function(String name, NoteData pack)? packUpdated,
+    TResult? Function(String name)? packRemoved,
+    TResult? Function(AnimationTrack animation)? animationAdded,
+    TResult? Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult? Function(String name)? animationRemoved,
+    TResult? Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult? Function()? presentationModeExited,
+    TResult? Function(int tick)? presentationTick,
+  }) {
+    return thumbnailCaptured?.call(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
+    TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
+    TResult Function(ViewOption view)? viewChanged,
+    TResult Function(UtilitiesState state)? utilitiesChanged,
+    TResult Function(List<PadElement> elements)? elementsCreated,
+    TResult Function(Map<int, List<PadElement>> elements)? elementsChanged,
+    TResult Function(List<int> elements)? elementsRemoved,
+    TResult Function(Arrangement arrangement, List<int> elements)?
+        elementsArranged,
+    TResult Function(String? name, String? description)?
+        documentDescriptionChanged,
+    TResult Function(String path)? documentPathChanged,
+    TResult Function(AssetLocation? location)? documentSaved,
+    TResult Function(Tool tool)? toolCreated,
+    TResult Function(Map<int, Tool> tools)? toolsChanged,
+    TResult Function(List<int> tools)? toolsRemoved,
+    TResult Function(int oldIndex, int newIndex)? toolReordered,
+    TResult Function(List<Background> backgrounds)? documentBackgroundsChanged,
+    TResult Function(Waypoint waypoint)? waypointCreated,
+    TResult Function(int index, String name)? waypointRenamed,
+    TResult Function(int index)? waypointRemoved,
+    TResult Function(String oldName, String newName)? layerRenamed,
+    TResult Function(String name)? layerRemoved,
+    TResult Function(String name)? layerElementsRemoved,
+    TResult Function(String name)? layerVisibilityChanged,
+    TResult Function(String name)? currentLayerChanged,
+    TResult Function(String layer, List<int> elements)? elementsLayerChanged,
+    TResult Function(String directory, String? remote, bool deleteDocument)?
+        templateCreated,
+    TResult Function(List<Area> areas)? areasCreated,
+    TResult Function(List<String> areas)? areasRemoved,
+    TResult Function(String name, Area area)? areaChanged,
+    TResult Function(String name)? currentAreaChanged,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetCreated,
+    TResult Function(String name, List<AreaPreset> areas)? exportPresetUpdated,
+    TResult Function(String name)? exportPresetRemoved,
+    TResult Function(NoteData pack)? packAdded,
+    TResult Function(String name, NoteData pack)? packUpdated,
+    TResult Function(String name)? packRemoved,
+    TResult Function(AnimationTrack animation)? animationAdded,
+    TResult Function(String name, AnimationTrack animation)? animationUpdated,
+    TResult Function(String name)? animationRemoved,
+    TResult Function(AnimationTrack track, bool fullScreen)?
+        presentationModeEntered,
+    TResult Function()? presentationModeExited,
+    TResult Function(int tick)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (thumbnailCaptured != null) {
+      return thumbnailCaptured(data);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
+    required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
+    required TResult Function(ViewChanged value) viewChanged,
+    required TResult Function(UtilitiesChanged value) utilitiesChanged,
+    required TResult Function(ElementsCreated value) elementsCreated,
+    required TResult Function(ElementsChanged value) elementsChanged,
+    required TResult Function(ElementsRemoved value) elementsRemoved,
+    required TResult Function(ElementsArranged value) elementsArranged,
+    required TResult Function(DocumentDescriptionChanged value)
+        documentDescriptionChanged,
+    required TResult Function(DocumentPathChanged value) documentPathChanged,
+    required TResult Function(DocumentSaved value) documentSaved,
+    required TResult Function(ToolCreated value) toolCreated,
+    required TResult Function(ToolsChanged value) toolsChanged,
+    required TResult Function(ToolsRemoved value) toolsRemoved,
+    required TResult Function(ToolReordered value) toolReordered,
+    required TResult Function(DocumentBackgroundsChanged value)
+        documentBackgroundsChanged,
+    required TResult Function(WaypointCreated value) waypointCreated,
+    required TResult Function(WaypointRenamed value) waypointRenamed,
+    required TResult Function(WaypointRemoved value) waypointRemoved,
+    required TResult Function(LayerRenamed value) layerRenamed,
+    required TResult Function(LayerRemoved value) layerRemoved,
+    required TResult Function(LayerElementsRemoved value) layerElementsRemoved,
+    required TResult Function(LayerVisibilityChanged value)
+        layerVisibilityChanged,
+    required TResult Function(CurrentLayerChanged value) currentLayerChanged,
+    required TResult Function(ElementsLayerChanged value) elementsLayerChanged,
+    required TResult Function(TemplateCreated value) templateCreated,
+    required TResult Function(AreasCreated value) areasCreated,
+    required TResult Function(AreasRemoved value) areasRemoved,
+    required TResult Function(AreaChanged value) areaChanged,
+    required TResult Function(CurrentAreaChanged value) currentAreaChanged,
+    required TResult Function(ExportPresetCreated value) exportPresetCreated,
+    required TResult Function(ExportPresetUpdated value) exportPresetUpdated,
+    required TResult Function(ExportPresetRemoved value) exportPresetRemoved,
+    required TResult Function(PackAdded value) packAdded,
+    required TResult Function(PackUpdated value) packUpdated,
+    required TResult Function(PackRemoved value) packRemoved,
+    required TResult Function(AnimationAdded value) animationAdded,
+    required TResult Function(AnimationUpdated value) animationUpdated,
+    required TResult Function(AnimationRemoved value) animationRemoved,
+    required TResult Function(PresentationModeEntered value)
+        presentationModeEntered,
+    required TResult Function(PresentationModeExited value)
+        presentationModeExited,
+    required TResult Function(PresentationTick value) presentationTick,
+  }) {
+    return thumbnailCaptured(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
+    TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult? Function(ViewChanged value)? viewChanged,
+    TResult? Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult? Function(ElementsCreated value)? elementsCreated,
+    TResult? Function(ElementsChanged value)? elementsChanged,
+    TResult? Function(ElementsRemoved value)? elementsRemoved,
+    TResult? Function(ElementsArranged value)? elementsArranged,
+    TResult? Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult? Function(DocumentPathChanged value)? documentPathChanged,
+    TResult? Function(DocumentSaved value)? documentSaved,
+    TResult? Function(ToolCreated value)? toolCreated,
+    TResult? Function(ToolsChanged value)? toolsChanged,
+    TResult? Function(ToolsRemoved value)? toolsRemoved,
+    TResult? Function(ToolReordered value)? toolReordered,
+    TResult? Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult? Function(WaypointCreated value)? waypointCreated,
+    TResult? Function(WaypointRenamed value)? waypointRenamed,
+    TResult? Function(WaypointRemoved value)? waypointRemoved,
+    TResult? Function(LayerRenamed value)? layerRenamed,
+    TResult? Function(LayerRemoved value)? layerRemoved,
+    TResult? Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult? Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult? Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult? Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult? Function(TemplateCreated value)? templateCreated,
+    TResult? Function(AreasCreated value)? areasCreated,
+    TResult? Function(AreasRemoved value)? areasRemoved,
+    TResult? Function(AreaChanged value)? areaChanged,
+    TResult? Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult? Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult? Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult? Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult? Function(PackAdded value)? packAdded,
+    TResult? Function(PackUpdated value)? packUpdated,
+    TResult? Function(PackRemoved value)? packRemoved,
+    TResult? Function(AnimationAdded value)? animationAdded,
+    TResult? Function(AnimationUpdated value)? animationUpdated,
+    TResult? Function(AnimationRemoved value)? animationRemoved,
+    TResult? Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult? Function(PresentationModeExited value)? presentationModeExited,
+    TResult? Function(PresentationTick value)? presentationTick,
+  }) {
+    return thumbnailCaptured?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
+    TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
+    TResult Function(ViewChanged value)? viewChanged,
+    TResult Function(UtilitiesChanged value)? utilitiesChanged,
+    TResult Function(ElementsCreated value)? elementsCreated,
+    TResult Function(ElementsChanged value)? elementsChanged,
+    TResult Function(ElementsRemoved value)? elementsRemoved,
+    TResult Function(ElementsArranged value)? elementsArranged,
+    TResult Function(DocumentDescriptionChanged value)?
+        documentDescriptionChanged,
+    TResult Function(DocumentPathChanged value)? documentPathChanged,
+    TResult Function(DocumentSaved value)? documentSaved,
+    TResult Function(ToolCreated value)? toolCreated,
+    TResult Function(ToolsChanged value)? toolsChanged,
+    TResult Function(ToolsRemoved value)? toolsRemoved,
+    TResult Function(ToolReordered value)? toolReordered,
+    TResult Function(DocumentBackgroundsChanged value)?
+        documentBackgroundsChanged,
+    TResult Function(WaypointCreated value)? waypointCreated,
+    TResult Function(WaypointRenamed value)? waypointRenamed,
+    TResult Function(WaypointRemoved value)? waypointRemoved,
+    TResult Function(LayerRenamed value)? layerRenamed,
+    TResult Function(LayerRemoved value)? layerRemoved,
+    TResult Function(LayerElementsRemoved value)? layerElementsRemoved,
+    TResult Function(LayerVisibilityChanged value)? layerVisibilityChanged,
+    TResult Function(CurrentLayerChanged value)? currentLayerChanged,
+    TResult Function(ElementsLayerChanged value)? elementsLayerChanged,
+    TResult Function(TemplateCreated value)? templateCreated,
+    TResult Function(AreasCreated value)? areasCreated,
+    TResult Function(AreasRemoved value)? areasRemoved,
+    TResult Function(AreaChanged value)? areaChanged,
+    TResult Function(CurrentAreaChanged value)? currentAreaChanged,
+    TResult Function(ExportPresetCreated value)? exportPresetCreated,
+    TResult Function(ExportPresetUpdated value)? exportPresetUpdated,
+    TResult Function(ExportPresetRemoved value)? exportPresetRemoved,
+    TResult Function(PackAdded value)? packAdded,
+    TResult Function(PackUpdated value)? packUpdated,
+    TResult Function(PackRemoved value)? packRemoved,
+    TResult Function(AnimationAdded value)? animationAdded,
+    TResult Function(AnimationUpdated value)? animationUpdated,
+    TResult Function(AnimationRemoved value)? animationRemoved,
+    TResult Function(PresentationModeEntered value)? presentationModeEntered,
+    TResult Function(PresentationModeExited value)? presentationModeExited,
+    TResult Function(PresentationTick value)? presentationTick,
+    required TResult orElse(),
+  }) {
+    if (thumbnailCaptured != null) {
+      return thumbnailCaptured(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ThumbnailCapturedToJson(
+      this,
+    );
+  }
+}
+
+abstract class ThumbnailCaptured extends DocumentEvent {
+  const factory ThumbnailCaptured(
+      @Uint8ListJsonConverter() final Uint8List data) = _$ThumbnailCaptured;
+  const ThumbnailCaptured._() : super._();
+
+  factory ThumbnailCaptured.fromJson(Map<String, dynamic> json) =
+      _$ThumbnailCaptured.fromJson;
+
+  @Uint8ListJsonConverter()
+  Uint8List get data;
+  @JsonKey(ignore: true)
+  _$$ThumbnailCapturedCopyWith<_$ThumbnailCaptured> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -927,7 +3288,13 @@ class _$ViewChanged extends ViewChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -986,7 +3353,13 @@ class _$ViewChanged extends ViewChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -1038,7 +3411,13 @@ class _$ViewChanged extends ViewChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -1094,7 +3473,12 @@ class _$ViewChanged extends ViewChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -1147,7 +3531,12 @@ class _$ViewChanged extends ViewChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -1197,7 +3586,12 @@ class _$ViewChanged extends ViewChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -1352,7 +3746,13 @@ class _$UtilitiesChanged extends UtilitiesChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -1411,7 +3811,13 @@ class _$UtilitiesChanged extends UtilitiesChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -1463,7 +3869,13 @@ class _$UtilitiesChanged extends UtilitiesChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -1519,7 +3931,12 @@ class _$UtilitiesChanged extends UtilitiesChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -1572,7 +3989,12 @@ class _$UtilitiesChanged extends UtilitiesChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -1622,7 +4044,12 @@ class _$UtilitiesChanged extends UtilitiesChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -1776,7 +4203,13 @@ class _$ElementsCreated extends ElementsCreated {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -1835,7 +4268,13 @@ class _$ElementsCreated extends ElementsCreated {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -1887,7 +4326,13 @@ class _$ElementsCreated extends ElementsCreated {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -1943,7 +4388,12 @@ class _$ElementsCreated extends ElementsCreated {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -1996,7 +4446,12 @@ class _$ElementsCreated extends ElementsCreated {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -2046,7 +4501,12 @@ class _$ElementsCreated extends ElementsCreated {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -2200,7 +4660,13 @@ class _$ElementsChanged extends ElementsChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -2259,7 +4725,13 @@ class _$ElementsChanged extends ElementsChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -2311,7 +4783,13 @@ class _$ElementsChanged extends ElementsChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -2367,7 +4845,12 @@ class _$ElementsChanged extends ElementsChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -2420,7 +4903,12 @@ class _$ElementsChanged extends ElementsChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -2470,7 +4958,12 @@ class _$ElementsChanged extends ElementsChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -2623,7 +5116,13 @@ class _$ElementsRemoved extends ElementsRemoved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -2682,7 +5181,13 @@ class _$ElementsRemoved extends ElementsRemoved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -2734,7 +5239,13 @@ class _$ElementsRemoved extends ElementsRemoved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -2790,7 +5301,12 @@ class _$ElementsRemoved extends ElementsRemoved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -2843,7 +5359,12 @@ class _$ElementsRemoved extends ElementsRemoved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -2893,7 +5414,12 @@ class _$ElementsRemoved extends ElementsRemoved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -3055,7 +5581,13 @@ class _$ElementsArranged extends ElementsArranged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -3114,7 +5646,13 @@ class _$ElementsArranged extends ElementsArranged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -3166,7 +5704,13 @@ class _$ElementsArranged extends ElementsArranged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -3222,7 +5766,12 @@ class _$ElementsArranged extends ElementsArranged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -3275,7 +5824,12 @@ class _$ElementsArranged extends ElementsArranged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -3325,7 +5879,12 @@ class _$ElementsArranged extends ElementsArranged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -3486,7 +6045,13 @@ class _$DocumentDescriptionChanged extends DocumentDescriptionChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -3545,7 +6110,13 @@ class _$DocumentDescriptionChanged extends DocumentDescriptionChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -3597,7 +6168,13 @@ class _$DocumentDescriptionChanged extends DocumentDescriptionChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -3653,7 +6230,12 @@ class _$DocumentDescriptionChanged extends DocumentDescriptionChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -3706,7 +6288,12 @@ class _$DocumentDescriptionChanged extends DocumentDescriptionChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -3756,7 +6343,12 @@ class _$DocumentDescriptionChanged extends DocumentDescriptionChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -3905,7 +6497,13 @@ class _$DocumentPathChanged extends DocumentPathChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -3964,7 +6562,13 @@ class _$DocumentPathChanged extends DocumentPathChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -4016,7 +6620,13 @@ class _$DocumentPathChanged extends DocumentPathChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -4072,7 +6682,12 @@ class _$DocumentPathChanged extends DocumentPathChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -4125,7 +6740,12 @@ class _$DocumentPathChanged extends DocumentPathChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -4175,7 +6795,12 @@ class _$DocumentPathChanged extends DocumentPathChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -4335,7 +6960,13 @@ class _$DocumentSaved extends DocumentSaved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -4394,7 +7025,13 @@ class _$DocumentSaved extends DocumentSaved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -4446,7 +7083,13 @@ class _$DocumentSaved extends DocumentSaved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -4502,7 +7145,12 @@ class _$DocumentSaved extends DocumentSaved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -4555,7 +7203,12 @@ class _$DocumentSaved extends DocumentSaved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -4605,7 +7258,12 @@ class _$DocumentSaved extends DocumentSaved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -4761,7 +7419,13 @@ class _$ToolCreated extends ToolCreated {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -4820,7 +7484,13 @@ class _$ToolCreated extends ToolCreated {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -4872,7 +7542,13 @@ class _$ToolCreated extends ToolCreated {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -4928,7 +7604,12 @@ class _$ToolCreated extends ToolCreated {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -4981,7 +7662,12 @@ class _$ToolCreated extends ToolCreated {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -5031,7 +7717,12 @@ class _$ToolCreated extends ToolCreated {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -5183,7 +7874,13 @@ class _$ToolsChanged extends ToolsChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -5242,7 +7939,13 @@ class _$ToolsChanged extends ToolsChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -5294,7 +7997,13 @@ class _$ToolsChanged extends ToolsChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -5350,7 +8059,12 @@ class _$ToolsChanged extends ToolsChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -5403,7 +8117,12 @@ class _$ToolsChanged extends ToolsChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -5453,7 +8172,12 @@ class _$ToolsChanged extends ToolsChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -5605,7 +8329,13 @@ class _$ToolsRemoved extends ToolsRemoved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -5664,7 +8394,13 @@ class _$ToolsRemoved extends ToolsRemoved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -5716,7 +8452,13 @@ class _$ToolsRemoved extends ToolsRemoved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -5772,7 +8514,12 @@ class _$ToolsRemoved extends ToolsRemoved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -5825,7 +8572,12 @@ class _$ToolsRemoved extends ToolsRemoved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -5875,7 +8627,12 @@ class _$ToolsRemoved extends ToolsRemoved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -6030,7 +8787,13 @@ class _$ToolReordered extends ToolReordered {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -6089,7 +8852,13 @@ class _$ToolReordered extends ToolReordered {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -6141,7 +8910,13 @@ class _$ToolReordered extends ToolReordered {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -6197,7 +8972,12 @@ class _$ToolReordered extends ToolReordered {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -6250,7 +9030,12 @@ class _$ToolReordered extends ToolReordered {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -6300,7 +9085,12 @@ class _$ToolReordered extends ToolReordered {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -6459,7 +9249,13 @@ class _$DocumentBackgroundsChanged extends DocumentBackgroundsChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -6518,7 +9314,13 @@ class _$DocumentBackgroundsChanged extends DocumentBackgroundsChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -6570,7 +9372,13 @@ class _$DocumentBackgroundsChanged extends DocumentBackgroundsChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -6626,7 +9434,12 @@ class _$DocumentBackgroundsChanged extends DocumentBackgroundsChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -6679,7 +9492,12 @@ class _$DocumentBackgroundsChanged extends DocumentBackgroundsChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -6729,7 +9547,12 @@ class _$DocumentBackgroundsChanged extends DocumentBackgroundsChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -6886,7 +9709,13 @@ class _$WaypointCreated extends WaypointCreated {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -6945,7 +9774,13 @@ class _$WaypointCreated extends WaypointCreated {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -6997,7 +9832,13 @@ class _$WaypointCreated extends WaypointCreated {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -7053,7 +9894,12 @@ class _$WaypointCreated extends WaypointCreated {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -7106,7 +9952,12 @@ class _$WaypointCreated extends WaypointCreated {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -7156,7 +10007,12 @@ class _$WaypointCreated extends WaypointCreated {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -7309,7 +10165,13 @@ class _$WaypointRenamed extends WaypointRenamed {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -7368,7 +10230,13 @@ class _$WaypointRenamed extends WaypointRenamed {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -7420,7 +10288,13 @@ class _$WaypointRenamed extends WaypointRenamed {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -7476,7 +10350,12 @@ class _$WaypointRenamed extends WaypointRenamed {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -7529,7 +10408,12 @@ class _$WaypointRenamed extends WaypointRenamed {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -7579,7 +10463,12 @@ class _$WaypointRenamed extends WaypointRenamed {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -7726,7 +10615,13 @@ class _$WaypointRemoved extends WaypointRemoved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -7785,7 +10680,13 @@ class _$WaypointRemoved extends WaypointRemoved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -7837,7 +10738,13 @@ class _$WaypointRemoved extends WaypointRemoved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -7893,7 +10800,12 @@ class _$WaypointRemoved extends WaypointRemoved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -7946,7 +10858,12 @@ class _$WaypointRemoved extends WaypointRemoved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -7996,7 +10913,12 @@ class _$WaypointRemoved extends WaypointRemoved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -8149,7 +11071,13 @@ class _$LayerRenamed extends LayerRenamed {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -8208,7 +11136,13 @@ class _$LayerRenamed extends LayerRenamed {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -8260,7 +11194,13 @@ class _$LayerRenamed extends LayerRenamed {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -8316,7 +11256,12 @@ class _$LayerRenamed extends LayerRenamed {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -8369,7 +11314,12 @@ class _$LayerRenamed extends LayerRenamed {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -8419,7 +11369,12 @@ class _$LayerRenamed extends LayerRenamed {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -8566,7 +11521,13 @@ class _$LayerRemoved extends LayerRemoved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -8625,7 +11586,13 @@ class _$LayerRemoved extends LayerRemoved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -8677,7 +11644,13 @@ class _$LayerRemoved extends LayerRemoved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -8733,7 +11706,12 @@ class _$LayerRemoved extends LayerRemoved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -8786,7 +11764,12 @@ class _$LayerRemoved extends LayerRemoved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -8836,7 +11819,12 @@ class _$LayerRemoved extends LayerRemoved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -8982,7 +11970,13 @@ class _$LayerElementsRemoved extends LayerElementsRemoved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -9041,7 +12035,13 @@ class _$LayerElementsRemoved extends LayerElementsRemoved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -9093,7 +12093,13 @@ class _$LayerElementsRemoved extends LayerElementsRemoved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -9149,7 +12155,12 @@ class _$LayerElementsRemoved extends LayerElementsRemoved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -9202,7 +12213,12 @@ class _$LayerElementsRemoved extends LayerElementsRemoved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -9252,7 +12268,12 @@ class _$LayerElementsRemoved extends LayerElementsRemoved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -9399,7 +12420,13 @@ class _$LayerVisibilityChanged extends LayerVisibilityChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -9458,7 +12485,13 @@ class _$LayerVisibilityChanged extends LayerVisibilityChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -9510,7 +12543,13 @@ class _$LayerVisibilityChanged extends LayerVisibilityChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -9566,7 +12605,12 @@ class _$LayerVisibilityChanged extends LayerVisibilityChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -9619,7 +12663,12 @@ class _$LayerVisibilityChanged extends LayerVisibilityChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -9669,7 +12718,12 @@ class _$LayerVisibilityChanged extends LayerVisibilityChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -9816,7 +12870,13 @@ class _$CurrentLayerChanged extends CurrentLayerChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -9875,7 +12935,13 @@ class _$CurrentLayerChanged extends CurrentLayerChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -9927,7 +12993,13 @@ class _$CurrentLayerChanged extends CurrentLayerChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -9983,7 +13055,12 @@ class _$CurrentLayerChanged extends CurrentLayerChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -10036,7 +13113,12 @@ class _$CurrentLayerChanged extends CurrentLayerChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -10086,7 +13168,12 @@ class _$CurrentLayerChanged extends CurrentLayerChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -10248,7 +13335,13 @@ class _$ElementsLayerChanged extends ElementsLayerChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -10307,7 +13400,13 @@ class _$ElementsLayerChanged extends ElementsLayerChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -10359,7 +13458,13 @@ class _$ElementsLayerChanged extends ElementsLayerChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -10415,7 +13520,12 @@ class _$ElementsLayerChanged extends ElementsLayerChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -10468,7 +13578,12 @@ class _$ElementsLayerChanged extends ElementsLayerChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -10518,7 +13633,12 @@ class _$ElementsLayerChanged extends ElementsLayerChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -10686,7 +13806,13 @@ class _$TemplateCreated extends TemplateCreated {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -10745,7 +13871,13 @@ class _$TemplateCreated extends TemplateCreated {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -10797,7 +13929,13 @@ class _$TemplateCreated extends TemplateCreated {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -10853,7 +13991,12 @@ class _$TemplateCreated extends TemplateCreated {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -10906,7 +14049,12 @@ class _$TemplateCreated extends TemplateCreated {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -10956,7 +14104,12 @@ class _$TemplateCreated extends TemplateCreated {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -11111,7 +14264,13 @@ class _$AreasCreated extends AreasCreated {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -11170,7 +14329,13 @@ class _$AreasCreated extends AreasCreated {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -11222,7 +14387,13 @@ class _$AreasCreated extends AreasCreated {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -11278,7 +14449,12 @@ class _$AreasCreated extends AreasCreated {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -11331,7 +14507,12 @@ class _$AreasCreated extends AreasCreated {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -11381,7 +14562,12 @@ class _$AreasCreated extends AreasCreated {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -11533,7 +14719,13 @@ class _$AreasRemoved extends AreasRemoved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -11592,7 +14784,13 @@ class _$AreasRemoved extends AreasRemoved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -11644,7 +14842,13 @@ class _$AreasRemoved extends AreasRemoved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -11700,7 +14904,12 @@ class _$AreasRemoved extends AreasRemoved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -11753,7 +14962,12 @@ class _$AreasRemoved extends AreasRemoved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -11803,7 +15017,12 @@ class _$AreasRemoved extends AreasRemoved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -11966,7 +15185,13 @@ class _$AreaChanged extends AreaChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -12025,7 +15250,13 @@ class _$AreaChanged extends AreaChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -12077,7 +15308,13 @@ class _$AreaChanged extends AreaChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -12133,7 +15370,12 @@ class _$AreaChanged extends AreaChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -12186,7 +15428,12 @@ class _$AreaChanged extends AreaChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -12236,7 +15483,12 @@ class _$AreaChanged extends AreaChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -12383,7 +15635,13 @@ class _$CurrentAreaChanged extends CurrentAreaChanged {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -12442,7 +15700,13 @@ class _$CurrentAreaChanged extends CurrentAreaChanged {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -12494,7 +15758,13 @@ class _$CurrentAreaChanged extends CurrentAreaChanged {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -12550,7 +15820,12 @@ class _$CurrentAreaChanged extends CurrentAreaChanged {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -12603,7 +15878,12 @@ class _$CurrentAreaChanged extends CurrentAreaChanged {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -12653,7 +15933,12 @@ class _$CurrentAreaChanged extends CurrentAreaChanged {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -12816,7 +16101,13 @@ class _$ExportPresetCreated extends ExportPresetCreated {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -12875,7 +16166,13 @@ class _$ExportPresetCreated extends ExportPresetCreated {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -12927,7 +16224,13 @@ class _$ExportPresetCreated extends ExportPresetCreated {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -12983,7 +16286,12 @@ class _$ExportPresetCreated extends ExportPresetCreated {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -13036,7 +16344,12 @@ class _$ExportPresetCreated extends ExportPresetCreated {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -13086,7 +16399,12 @@ class _$ExportPresetCreated extends ExportPresetCreated {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -13250,7 +16568,13 @@ class _$ExportPresetUpdated extends ExportPresetUpdated {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -13309,7 +16633,13 @@ class _$ExportPresetUpdated extends ExportPresetUpdated {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -13361,7 +16691,13 @@ class _$ExportPresetUpdated extends ExportPresetUpdated {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -13417,7 +16753,12 @@ class _$ExportPresetUpdated extends ExportPresetUpdated {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -13470,7 +16811,12 @@ class _$ExportPresetUpdated extends ExportPresetUpdated {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -13520,7 +16866,12 @@ class _$ExportPresetUpdated extends ExportPresetUpdated {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -13668,7 +17019,13 @@ class _$ExportPresetRemoved extends ExportPresetRemoved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -13727,7 +17084,13 @@ class _$ExportPresetRemoved extends ExportPresetRemoved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -13779,7 +17142,13 @@ class _$ExportPresetRemoved extends ExportPresetRemoved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -13835,7 +17204,12 @@ class _$ExportPresetRemoved extends ExportPresetRemoved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -13888,7 +17262,12 @@ class _$ExportPresetRemoved extends ExportPresetRemoved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -13938,7 +17317,12 @@ class _$ExportPresetRemoved extends ExportPresetRemoved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -14083,7 +17467,13 @@ class _$PackAdded extends PackAdded {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -14142,7 +17532,13 @@ class _$PackAdded extends PackAdded {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -14194,7 +17590,13 @@ class _$PackAdded extends PackAdded {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -14250,7 +17652,12 @@ class _$PackAdded extends PackAdded {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -14303,7 +17710,12 @@ class _$PackAdded extends PackAdded {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -14353,7 +17765,12 @@ class _$PackAdded extends PackAdded {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -14505,7 +17922,13 @@ class _$PackUpdated extends PackUpdated {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -14564,7 +17987,13 @@ class _$PackUpdated extends PackUpdated {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -14616,7 +18045,13 @@ class _$PackUpdated extends PackUpdated {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -14672,7 +18107,12 @@ class _$PackUpdated extends PackUpdated {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -14725,7 +18165,12 @@ class _$PackUpdated extends PackUpdated {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -14775,7 +18220,12 @@ class _$PackUpdated extends PackUpdated {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -14922,7 +18372,13 @@ class _$PackRemoved extends PackRemoved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -14981,7 +18437,13 @@ class _$PackRemoved extends PackRemoved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -15033,7 +18495,13 @@ class _$PackRemoved extends PackRemoved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -15089,7 +18557,12 @@ class _$PackRemoved extends PackRemoved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -15142,7 +18615,12 @@ class _$PackRemoved extends PackRemoved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -15192,7 +18670,12 @@ class _$PackRemoved extends PackRemoved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -15348,7 +18831,13 @@ class _$AnimationAdded extends AnimationAdded {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -15407,7 +18896,13 @@ class _$AnimationAdded extends AnimationAdded {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -15459,7 +18954,13 @@ class _$AnimationAdded extends AnimationAdded {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -15515,7 +19016,12 @@ class _$AnimationAdded extends AnimationAdded {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -15568,7 +19074,12 @@ class _$AnimationAdded extends AnimationAdded {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -15618,7 +19129,12 @@ class _$AnimationAdded extends AnimationAdded {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -15783,7 +19299,13 @@ class _$AnimationUpdated extends AnimationUpdated {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -15842,7 +19364,13 @@ class _$AnimationUpdated extends AnimationUpdated {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -15894,7 +19422,13 @@ class _$AnimationUpdated extends AnimationUpdated {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -15950,7 +19484,12 @@ class _$AnimationUpdated extends AnimationUpdated {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -16003,7 +19542,12 @@ class _$AnimationUpdated extends AnimationUpdated {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -16053,7 +19597,12 @@ class _$AnimationUpdated extends AnimationUpdated {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -16200,7 +19749,13 @@ class _$AnimationRemoved extends AnimationRemoved {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -16259,7 +19814,13 @@ class _$AnimationRemoved extends AnimationRemoved {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -16311,7 +19872,13 @@ class _$AnimationRemoved extends AnimationRemoved {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -16367,7 +19934,12 @@ class _$AnimationRemoved extends AnimationRemoved {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -16420,7 +19992,12 @@ class _$AnimationRemoved extends AnimationRemoved {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -16470,7 +20047,12 @@ class _$AnimationRemoved extends AnimationRemoved {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -16636,7 +20218,13 @@ class _$PresentationModeEntered extends PresentationModeEntered {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -16695,7 +20283,13 @@ class _$PresentationModeEntered extends PresentationModeEntered {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -16747,7 +20341,13 @@ class _$PresentationModeEntered extends PresentationModeEntered {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -16803,7 +20403,12 @@ class _$PresentationModeEntered extends PresentationModeEntered {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -16856,7 +20461,12 @@ class _$PresentationModeEntered extends PresentationModeEntered {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -16906,7 +20516,12 @@ class _$PresentationModeEntered extends PresentationModeEntered {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -17028,7 +20643,13 @@ class _$PresentationModeExited extends PresentationModeExited {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -17087,7 +20708,13 @@ class _$PresentationModeExited extends PresentationModeExited {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -17139,7 +20766,13 @@ class _$PresentationModeExited extends PresentationModeExited {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -17195,7 +20828,12 @@ class _$PresentationModeExited extends PresentationModeExited {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -17248,7 +20886,12 @@ class _$PresentationModeExited extends PresentationModeExited {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -17298,7 +20941,12 @@ class _$PresentationModeExited extends PresentationModeExited {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,
@@ -17438,7 +21086,13 @@ class _$PresentationTick extends PresentationTick {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(DocumentPage page, int? index) pageAdded,
     required TResult Function(String pageName) pageChanged,
+    required TResult Function(String page, int? newIndex) pageReordered,
+    required TResult Function(String oldName, String newName) pageRenamed,
+    required TResult Function(String page) pageRemoved,
+    required TResult Function(@Uint8ListJsonConverter() Uint8List data)
+        thumbnailCaptured,
     required TResult Function(ViewOption view) viewChanged,
     required TResult Function(UtilitiesState state) utilitiesChanged,
     required TResult Function(List<PadElement> elements) elementsCreated,
@@ -17497,7 +21151,13 @@ class _$PresentationTick extends PresentationTick {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DocumentPage page, int? index)? pageAdded,
     TResult? Function(String pageName)? pageChanged,
+    TResult? Function(String page, int? newIndex)? pageReordered,
+    TResult? Function(String oldName, String newName)? pageRenamed,
+    TResult? Function(String page)? pageRemoved,
+    TResult? Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult? Function(ViewOption view)? viewChanged,
     TResult? Function(UtilitiesState state)? utilitiesChanged,
     TResult? Function(List<PadElement> elements)? elementsCreated,
@@ -17549,7 +21209,13 @@ class _$PresentationTick extends PresentationTick {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DocumentPage page, int? index)? pageAdded,
     TResult Function(String pageName)? pageChanged,
+    TResult Function(String page, int? newIndex)? pageReordered,
+    TResult Function(String oldName, String newName)? pageRenamed,
+    TResult Function(String page)? pageRemoved,
+    TResult Function(@Uint8ListJsonConverter() Uint8List data)?
+        thumbnailCaptured,
     TResult Function(ViewOption view)? viewChanged,
     TResult Function(UtilitiesState state)? utilitiesChanged,
     TResult Function(List<PadElement> elements)? elementsCreated,
@@ -17605,7 +21271,12 @@ class _$PresentationTick extends PresentationTick {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(PageAdded value) pageAdded,
     required TResult Function(PageChanged value) pageChanged,
+    required TResult Function(PageReordered value) pageReordered,
+    required TResult Function(PageRenamed value) pageRenamed,
+    required TResult Function(PageRemoved value) pageRemoved,
+    required TResult Function(ThumbnailCaptured value) thumbnailCaptured,
     required TResult Function(ViewChanged value) viewChanged,
     required TResult Function(UtilitiesChanged value) utilitiesChanged,
     required TResult Function(ElementsCreated value) elementsCreated,
@@ -17658,7 +21329,12 @@ class _$PresentationTick extends PresentationTick {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PageAdded value)? pageAdded,
     TResult? Function(PageChanged value)? pageChanged,
+    TResult? Function(PageReordered value)? pageReordered,
+    TResult? Function(PageRenamed value)? pageRenamed,
+    TResult? Function(PageRemoved value)? pageRemoved,
+    TResult? Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult? Function(ViewChanged value)? viewChanged,
     TResult? Function(UtilitiesChanged value)? utilitiesChanged,
     TResult? Function(ElementsCreated value)? elementsCreated,
@@ -17708,7 +21384,12 @@ class _$PresentationTick extends PresentationTick {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(PageAdded value)? pageAdded,
     TResult Function(PageChanged value)? pageChanged,
+    TResult Function(PageReordered value)? pageReordered,
+    TResult Function(PageRenamed value)? pageRenamed,
+    TResult Function(PageRemoved value)? pageRemoved,
+    TResult Function(ThumbnailCaptured value)? thumbnailCaptured,
     TResult Function(ViewChanged value)? viewChanged,
     TResult Function(UtilitiesChanged value)? utilitiesChanged,
     TResult Function(ElementsCreated value)? elementsCreated,

--- a/api/lib/src/protocol/event.g.dart
+++ b/api/lib/src/protocol/event.g.dart
@@ -6,6 +6,19 @@ part of 'event.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+_$PageAdded _$$PageAddedFromJson(Map json) => _$PageAdded(
+      DocumentPage.fromJson(Map<String, dynamic>.from(json['page'] as Map)),
+      json['index'] as int?,
+      json['type'] as String?,
+    );
+
+Map<String, dynamic> _$$PageAddedToJson(_$PageAdded instance) =>
+    <String, dynamic>{
+      'page': instance.page.toJson(),
+      'index': instance.index,
+      'type': instance.$type,
+    };
+
 _$PageChanged _$$PageChangedFromJson(Map json) => _$PageChanged(
       json['pageName'] as String,
       $type: json['type'] as String?,
@@ -14,6 +27,55 @@ _$PageChanged _$$PageChangedFromJson(Map json) => _$PageChanged(
 Map<String, dynamic> _$$PageChangedToJson(_$PageChanged instance) =>
     <String, dynamic>{
       'pageName': instance.pageName,
+      'type': instance.$type,
+    };
+
+_$PageReordered _$$PageReorderedFromJson(Map json) => _$PageReordered(
+      json['page'] as String,
+      json['newIndex'] as int?,
+      json['type'] as String?,
+    );
+
+Map<String, dynamic> _$$PageReorderedToJson(_$PageReordered instance) =>
+    <String, dynamic>{
+      'page': instance.page,
+      'newIndex': instance.newIndex,
+      'type': instance.$type,
+    };
+
+_$PageRenamed _$$PageRenamedFromJson(Map json) => _$PageRenamed(
+      json['oldName'] as String,
+      json['newName'] as String,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$$PageRenamedToJson(_$PageRenamed instance) =>
+    <String, dynamic>{
+      'oldName': instance.oldName,
+      'newName': instance.newName,
+      'type': instance.$type,
+    };
+
+_$PageRemoved _$$PageRemovedFromJson(Map json) => _$PageRemoved(
+      json['page'] as String,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$$PageRemovedToJson(_$PageRemoved instance) =>
+    <String, dynamic>{
+      'page': instance.page,
+      'type': instance.$type,
+    };
+
+_$ThumbnailCaptured _$$ThumbnailCapturedFromJson(Map json) =>
+    _$ThumbnailCaptured(
+      const Uint8ListJsonConverter().fromJson(json['data'] as String),
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$$ThumbnailCapturedToJson(_$ThumbnailCaptured instance) =>
+    <String, dynamic>{
+      'data': const Uint8ListJsonConverter().toJson(instance.data),
       'type': instance.$type,
     };
 

--- a/app/lib/api/file_system/file_system.dart
+++ b/app/lib/api/file_system/file_system.dart
@@ -196,7 +196,7 @@ abstract class TemplateFileSystem extends GeneralFileSystem {
     final metadata = template.getMetadata();
     if (metadata == null) return template;
     final name = await findAvailableName(metadata.name);
-    template.setMetadata(metadata.copyWith(name: name));
+    template = template.setMetadata(metadata.copyWith(name: name));
     await updateTemplate(template);
     return template;
   }
@@ -211,11 +211,11 @@ abstract class TemplateFileSystem extends GeneralFileSystem {
     if (path.startsWith('/')) {
       path = path.substring(1);
     }
-    final template = await getTemplate(path);
+    var template = await getTemplate(path);
     if (template == null) return null;
     final metadata = template.getMetadata()?.copyWith(name: newName);
     if (metadata == null) return null;
-    template.setMetadata(metadata);
+    template = template.setMetadata(metadata);
     final newTemplate = await createTemplate(template);
     await deleteTemplate(path);
     return newTemplate;
@@ -263,7 +263,7 @@ abstract class PackFileSystem extends GeneralFileSystem {
     final metadata = pack.getMetadata();
     if (metadata == null) return pack;
     final newName = await findAvailableName(metadata.name);
-    pack.setMetadata(metadata.copyWith(name: newName));
+    pack = pack.setMetadata(metadata.copyWith(name: newName));
     updatePack(pack);
     return pack;
   }
@@ -278,11 +278,11 @@ abstract class PackFileSystem extends GeneralFileSystem {
     if (path.startsWith('/')) {
       path = path.substring(1);
     }
-    final pack = await getPack(path);
+    var pack = await getPack(path);
     final metadata = pack?.getMetadata();
     if (pack == null || metadata == null) return null;
     await deletePack(path);
-    pack.setMetadata(metadata.copyWith(name: newName));
+    pack = pack.setMetadata(metadata.copyWith(name: newName));
     await updatePack(pack);
     return pack;
   }

--- a/app/lib/bloc/document_bloc.dart
+++ b/app/lib/bloc/document_bloc.dart
@@ -61,7 +61,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
     on<PageAdded>((event, emit) async {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
-      var (newData, pageName) = current.data.addPage(event.page, event.index);
+      final (newData, pageName) = current.data.addPage(event.page, event.index);
       return _saveState(
         emit,
         current.copyWith(data: newData, pageName: pageName),
@@ -90,7 +90,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
     on<PageReordered>((event, emit) async {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
-      var newData = current.data.reorderPage(event.page, event.newIndex);
+      final newData = current.data.reorderPage(event.page, event.newIndex);
       return _saveState(
         emit,
         current.copyWith(data: newData),
@@ -100,7 +100,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
     on<PageRenamed>((event, emit) async {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
-      var newData = current.data.renamePage(event.oldName, event.newName);
+      final newData = current.data.renamePage(event.oldName, event.newName);
       return _saveState(
         emit,
         current.copyWith(data: newData),
@@ -110,7 +110,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
     on<PageRemoved>((event, emit) async {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
-      var newData = current.data.removePage(event.page);
+      final newData = current.data.removePage(event.page);
       return _saveState(
         emit,
         current.copyWith(data: newData),
@@ -120,7 +120,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
     on<ThumbnailCaptured>((event, emit) async {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
-      var newData = current.data.setThumbnail(event.data);
+      final newData = current.data.setThumbnail(event.data);
       return _saveState(
         emit,
         current.copyWith(data: newData),

--- a/app/lib/bloc/document_bloc.dart
+++ b/app/lib/bloc/document_bloc.dart
@@ -61,7 +61,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
     on<PageChanged>((event, emit) async {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
-      current.data.setPage(current.page, current.pageName);
+      final data = current.data.setPage(current.page, current.pageName);
       final page = current.data.getPage(event.pageName);
       if (page == null) return;
       current.currentIndexCubit
@@ -71,6 +71,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
         emit,
         current.copyWith(
           page: page,
+          data: data,
           pageName: event.pageName,
         ),
         null,
@@ -80,8 +81,23 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
       if (!(current.embedding?.editable ?? true)) return;
-      final renderers =
-          event.elements.map((e) => Renderer.fromInstance(e)).toList();
+      var data = current.data;
+      String importImage(String source, String fileExtension) {
+        final uriData = Uri.tryParse(source)?.data;
+        if (uriData == null) return source;
+        final result = data.addImage(uriData.contentAsBytes(), fileExtension);
+        data = result.$1;
+        return result.$2;
+      }
+
+      final elements = event.elements.map((e) => e.maybeMap(
+            image: (value) =>
+                value.copyWith(source: importImage(value.source, 'png')),
+            svg: (value) =>
+                value.copyWith(source: importImage(value.source, 'svg')),
+            orElse: () => e,
+          ));
+      final renderers = elements.map((e) => Renderer.fromInstance(e)).toList();
       if (renderers.isEmpty) return;
       if (current.currentIndexCubit
           .getHandler()
@@ -93,7 +109,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
           current.copyWith(
               page: current.page.copyWith(
                   content: (List.from(current.page.content)
-                    ..addAll(renderers.map((e) => e.element))))),
+                    ..addAll(elements)))),
           renderers);
     }, transformer: sequential());
     on<ElementsChanged>((event, emit) async {
@@ -247,12 +263,12 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
           unusedAssets.add(element.source);
         }
       });
+      final data = current.data.removeAssets(unusedAssets.toList());
       for (var asset in unusedAssets) {
-        current.data.removeAsset(asset);
         current.assetService.removeImage(asset);
       }
 
-      await _saveState(emit, current.copyWith(page: newPage), null);
+      await _saveState(emit, current.copyWith(page: newPage, data: data), null);
     }, transformer: sequential());
     on<DocumentDescriptionChanged>((event, emit) async {
       final current = state;
@@ -676,23 +692,29 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
         name = '${event.pack.name} ($i)';
         i++;
       }
-      event.pack.name = name;
-      current.data.setPack(event.pack);
-      _saveState(emit);
+      final pack = event.pack.setName(name);
+      _saveState(
+        emit,
+        current.copyWith(data: current.data.setPack(pack)),
+      );
     });
     on<PackUpdated>((event, emit) {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
       if (!(current.embedding?.editable ?? true)) return;
-      current.data.setPack(event.pack);
-      _saveState(emit);
+      _saveState(
+        emit,
+        current.copyWith(data: current.data.setPack(event.pack)),
+      );
     });
     on<PackRemoved>((event, emit) {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
       if (!(current.embedding?.editable ?? true)) return;
-      current.data.removePack(event.name);
-      _saveState(emit);
+      _saveState(
+        emit,
+        current.copyWith(data: current.data.removePack(event.name)),
+      );
     });
     on<AnimationAdded>((event, emit) {
       final current = state;
@@ -835,5 +857,9 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
     currentIndexCubit.unbake(tool: tool);
     currentIndexCubit.loadElements(document, assetService, page);
     currentIndexCubit.init(this);
+  }
+
+  void dispose() {
+    state.assetService?.dispose();
   }
 }

--- a/app/lib/dialogs/background/general.dart
+++ b/app/lib/dialogs/background/general.dart
@@ -57,8 +57,7 @@ class _GeneralBackgroundPropertiesView extends StatelessWidget {
                 if (!kIsWeb) {
                   content = await File(e.path ?? '').readAsBytes();
                 }
-                final assetPath = state.data.addImage(content, 'png');
-                final dataPath = Uri.file(assetPath, windows: false).toString();
+                final dataPath = Uri.dataFromBytes(content).toString();
                 final codec = await ui.instantiateImageCodec(content);
                 final frame = await codec.getNextFrame();
                 final image = frame.image;

--- a/app/lib/dialogs/color_pick.dart
+++ b/app/lib/dialogs/color_pick.dart
@@ -69,10 +69,9 @@ class _ColorPalettePickerDialogState extends State<ColorPalettePickerDialog> {
     } else {
       final state = widget.bloc?.state;
       if (state is! DocumentLoaded) return;
-      final pack =
-          _selected == null ? null : state.data.getPack(_selected!.name);
+      var pack = _selected == null ? null : state.data.getPack(_selected!.name);
       if (pack == null) return;
-      pack.setPalette(palette);
+      pack = pack.setPalette(palette);
       widget.bloc?.add(PackUpdated(pack.name!, pack));
     }
   }

--- a/app/lib/dialogs/packs/asset.dart
+++ b/app/lib/dialogs/packs/asset.dart
@@ -130,7 +130,7 @@ Future<void> addToPack(
     ),
   );
   if (result == null) return;
-  final pack = document.getPack(result.pack);
+  var pack = document.getPack(result.pack);
   if (pack == null) return;
   final screenshot = await state.currentIndexCubit.render(
     state.data,
@@ -145,10 +145,10 @@ Future<void> addToPack(
   );
   String? thumbnailUri;
   if (screenshot != null) {
-    final thumbnailPath = pack.addImage(screenshot.buffer.asUint8List(), 'png');
-    thumbnailUri = Uri.file(thumbnailPath, windows: false).toString();
+    thumbnailUri =
+        Uri.dataFromBytes(screenshot.buffer.asUint8List()).toString();
   }
-  pack.setComponent(ButterflyComponent(
+  pack = pack.setComponent(ButterflyComponent(
     name: result.name,
     elements: elements,
     thumbnail: thumbnailUri,

--- a/app/lib/dialogs/packs/components.dart
+++ b/app/lib/dialogs/packs/components.dart
@@ -25,16 +25,14 @@ class ComponentsPackView extends StatelessWidget {
                 (e) => Dismissible(
                   key: ValueKey(e),
                   onDismissed: (direction) {
-                    value.removeComponent(e);
-                    onChanged(value);
+                    onChanged(value.removeComponent(e));
                   },
                   child: ListTile(
                     title: Text(e),
                     trailing: IconButton(
                       icon: const PhosphorIcon(PhosphorIconsLight.trash),
                       onPressed: () async {
-                        value.removeComponent(e);
-                        onChanged(value);
+                        onChanged(value.removeComponent(e));
                       },
                     ),
                   ),

--- a/app/lib/dialogs/packs/dialog.dart
+++ b/app/lib/dialogs/packs/dialog.dart
@@ -85,120 +85,106 @@ class _PacksDialogState extends State<PacksDialog>
                     Flexible(
                       child: TabBarView(controller: _controller, children: [
                         if (!widget.globalOnly)
-                          Builder(builder: (context) {
-                            final state = context.read<DocumentBloc>().state;
+                          BlocBuilder<DocumentBloc, DocumentState>(
+                              builder: (context, state) {
                             if (state is! DocumentLoadSuccess) {
                               return Container();
                             }
-                            return StreamBuilder<Iterable<String>>(
-                                stream: state.data.onChange
-                                    .map((event) => event.getPacks()),
-                                builder: (context, snapshot) {
-                                  final packs = snapshot.data?.toList() ?? [];
-                                  return ListView.builder(
-                                    shrinkWrap: true,
-                                    itemCount: packs.length,
-                                    itemBuilder: (context, index) {
-                                      final pack =
-                                          state.data.getPack(packs[index]);
-                                      final metadata = pack?.getMetadata();
-                                      if (metadata == null) return Container();
-                                      return Dismissible(
-                                        key: ValueKey(
-                                            ('localpack', metadata.name)),
-                                        onDismissed: (direction) {
-                                          context
-                                              .read<DocumentBloc>()
-                                              .add(PackRemoved(metadata.name));
-                                        },
-                                        background: Container(
-                                          color: Colors.red,
-                                        ),
-                                        child: ListTile(
-                                          title: Text(metadata.name),
-                                          subtitle: Column(
-                                            crossAxisAlignment:
-                                                CrossAxisAlignment.start,
-                                            children: [
-                                              if (metadata.author.isNotEmpty)
-                                                Text(AppLocalizations.of(
-                                                        context)
-                                                    .byAuthor(metadata.author)),
-                                              if (metadata
-                                                  .description.isNotEmpty)
-                                                Text(metadata.description),
-                                            ],
-                                          ),
-                                          onTap: () async {
-                                            final bloc =
-                                                context.read<DocumentBloc>();
-                                            Navigator.of(context).pop();
-                                            final newPack =
-                                                await showDialog<NoteData>(
-                                                    context: context,
-                                                    builder: (context) =>
-                                                        BlocProvider.value(
-                                                            value: bloc,
-                                                            child: PackDialog(
-                                                                pack: pack)));
-                                            if (newPack == null) return;
-                                            bloc.add(PackUpdated(
-                                                metadata.name, newPack));
-                                          },
-                                          trailing: MenuAnchor(
-                                            builder: defaultMenuButton(),
-                                            menuChildren: [
-                                              MenuItemButton(
-                                                leadingIcon: const PhosphorIcon(
-                                                    PhosphorIconsLight
-                                                        .appWindow),
-                                                child: Text(
-                                                    AppLocalizations.of(context)
-                                                        .local),
-                                                onPressed: () async {
-                                                  await _addPack(pack!, true);
-                                                  if (mounted) {
-                                                    setState(() {});
-                                                  }
-                                                },
-                                              ),
-                                              MenuItemButton(
-                                                leadingIcon: const PhosphorIcon(
-                                                    PhosphorIconsLight
-                                                        .download),
-                                                child: Text(
-                                                    AppLocalizations.of(context)
-                                                        .export),
-                                                onPressed: () async {
-                                                  await _exportPack(pack!);
-                                                  if (mounted) {
-                                                    setState(() {});
-                                                  }
-                                                },
-                                              ),
-                                              MenuItemButton(
-                                                leadingIcon: const PhosphorIcon(
-                                                    PhosphorIconsLight.trash),
-                                                child: Text(
-                                                    AppLocalizations.of(context)
-                                                        .delete),
-                                                onPressed: () {
-                                                  context
-                                                      .read<DocumentBloc>()
-                                                      .add(PackRemoved(
-                                                          metadata.name));
-                                                  if (mounted) {
-                                                    setState(() {});
-                                                  }
-                                                },
-                                              ),
-                                            ],
-                                          ),
-                                        ),
-                                      );
+                            final packs = state.data.getPacks().toList();
+                            return ListView.builder(
+                              shrinkWrap: true,
+                              itemCount: packs.length,
+                              itemBuilder: (context, index) {
+                                final pack = state.data.getPack(packs[index]);
+                                final metadata = pack?.getMetadata();
+                                if (metadata == null) return Container();
+                                return Dismissible(
+                                  key: ValueKey(('localpack', metadata.name)),
+                                  onDismissed: (direction) {
+                                    context
+                                        .read<DocumentBloc>()
+                                        .add(PackRemoved(metadata.name));
+                                  },
+                                  background: Container(
+                                    color: Colors.red,
+                                  ),
+                                  child: ListTile(
+                                    title: Text(metadata.name),
+                                    subtitle: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        if (metadata.author.isNotEmpty)
+                                          Text(AppLocalizations.of(context)
+                                              .byAuthor(metadata.author)),
+                                        if (metadata.description.isNotEmpty)
+                                          Text(metadata.description),
+                                      ],
+                                    ),
+                                    onTap: () async {
+                                      final bloc = context.read<DocumentBloc>();
+                                      Navigator.of(context).pop();
+                                      final newPack =
+                                          await showDialog<NoteData>(
+                                              context: context,
+                                              builder: (context) =>
+                                                  BlocProvider.value(
+                                                      value: bloc,
+                                                      child: PackDialog(
+                                                          pack: pack)));
+                                      if (newPack == null) return;
+                                      bloc.add(
+                                          PackUpdated(metadata.name, newPack));
                                     },
-                                  );
-                                });
+                                    trailing: MenuAnchor(
+                                      builder: defaultMenuButton(),
+                                      menuChildren: [
+                                        MenuItemButton(
+                                          leadingIcon: const PhosphorIcon(
+                                              PhosphorIconsLight.appWindow),
+                                          child: Text(
+                                              AppLocalizations.of(context)
+                                                  .local),
+                                          onPressed: () async {
+                                            await _addPack(pack!, true);
+                                            if (mounted) {
+                                              setState(() {});
+                                            }
+                                          },
+                                        ),
+                                        MenuItemButton(
+                                          leadingIcon: const PhosphorIcon(
+                                              PhosphorIconsLight.download),
+                                          child: Text(
+                                              AppLocalizations.of(context)
+                                                  .export),
+                                          onPressed: () async {
+                                            await _exportPack(pack!);
+                                            if (mounted) {
+                                              setState(() {});
+                                            }
+                                          },
+                                        ),
+                                        MenuItemButton(
+                                          leadingIcon: const PhosphorIcon(
+                                              PhosphorIconsLight.trash),
+                                          child: Text(
+                                              AppLocalizations.of(context)
+                                                  .delete),
+                                          onPressed: () {
+                                            context.read<DocumentBloc>().add(
+                                                PackRemoved(metadata.name));
+                                            if (mounted) {
+                                              setState(() {});
+                                            }
+                                          },
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                );
+                              },
+                            );
                           }),
                         FutureBuilder<List<NoteData>>(
                           future: _fileSystem

--- a/app/lib/dialogs/packs/general.dart
+++ b/app/lib/dialogs/packs/general.dart
@@ -20,8 +20,7 @@ class GeneralPackView extends StatelessWidget {
       return const SizedBox();
     }
     void changeMetadata(FileMetadata metadata) {
-      value.setMetadata(metadata);
-      onChanged(value);
+      onChanged(value.setMetadata(metadata));
     }
 
     return ListView(

--- a/app/lib/dialogs/packs/pack.dart
+++ b/app/lib/dialogs/packs/pack.dart
@@ -30,7 +30,7 @@ class _PackDialogState extends State<PackDialog> {
 
   void _onChanged(NoteData pack) {
     setState(() {
-      pack.setMetadata(pack.getMetadata()!.copyWith(
+      pack = pack.setMetadata(pack.getMetadata()!.copyWith(
             updatedAt: DateTime.now().toUtc(),
           ));
     });

--- a/app/lib/dialogs/packs/pack.dart
+++ b/app/lib/dialogs/packs/pack.dart
@@ -30,7 +30,7 @@ class _PackDialogState extends State<PackDialog> {
 
   void _onChanged(NoteData pack) {
     setState(() {
-      pack = pack.setMetadata(pack.getMetadata()!.copyWith(
+      this.pack = pack.setMetadata(pack.getMetadata()!.copyWith(
             updatedAt: DateTime.now().toUtc(),
           ));
     });

--- a/app/lib/dialogs/packs/palettes.dart
+++ b/app/lib/dialogs/packs/palettes.dart
@@ -71,8 +71,7 @@ class PalettesPackView extends StatelessWidget {
                 ),
               );
               if (name == null) return;
-              value.setPalette(ColorPalette(name: name));
-              onChanged(value);
+              onChanged(value.setPalette(ColorPalette(name: name)));
             },
             icon: const PhosphorIcon(PhosphorIconsLight.plus),
             label: Text(AppLocalizations.of(context).create),

--- a/app/lib/dialogs/packs/palettes.dart
+++ b/app/lib/dialogs/packs/palettes.dart
@@ -30,8 +30,7 @@ class PalettesPackView extends StatelessWidget {
                     (e) => Dismissible(
                       key: ValueKey(e),
                       onDismissed: (direction) {
-                        value.removePalette(e);
-                        onChanged(value);
+                        onChanged(value.removePalette(e));
                       },
                       child: ListTile(
                         title: Text(e),
@@ -42,8 +41,7 @@ class PalettesPackView extends StatelessWidget {
                               palette: value.getPalette(e),
                               viewMode: true,
                               onChanged: (palette) {
-                                value.setPalette(palette);
-                                onChanged(value);
+                                onChanged(value.setPalette(palette));
                               },
                             ),
                           );
@@ -51,8 +49,7 @@ class PalettesPackView extends StatelessWidget {
                         trailing: IconButton(
                           icon: const PhosphorIcon(PhosphorIconsLight.trash),
                           onPressed: () async {
-                            value.removePalette(e);
-                            onChanged(value);
+                            onChanged(value.removePalette(e));
                           },
                         ),
                       ),

--- a/app/lib/dialogs/packs/select.dart
+++ b/app/lib/dialogs/packs/select.dart
@@ -47,18 +47,12 @@ class SelectPackAssetDialog extends StatelessWidget {
     }
   }
 
-  void _createAsset(NoteData pack, String name) {
-    switch (type) {
-      case PackAssetType.component:
-        pack.setComponent(ButterflyComponent(name: name));
-        break;
-      case PackAssetType.style:
-        pack.setStyle(text.TextStyleSheet(name: name));
-        break;
-      case PackAssetType.palette:
-        pack.setPalette(ColorPalette(name: name));
-    }
-  }
+  NoteData _createAsset(NoteData pack, String name) => switch (type) {
+        PackAssetType.component =>
+          pack.setComponent(ButterflyComponent(name: name)),
+        PackAssetType.style => pack.setStyle(text.TextStyleSheet(name: name)),
+        PackAssetType.palette => pack.setPalette(ColorPalette(name: name)),
+      };
 
   @override
   Widget build(BuildContext context) {
@@ -84,8 +78,8 @@ class SelectPackAssetDialog extends StatelessWidget {
                 if (context.mounted) {
                   final pack = state.data.getPack(result.pack);
                   if (pack == null) return;
-                  _createAsset(pack, result.name);
-                  bloc.add(PackUpdated(pack.name!, pack));
+                  bloc.add(
+                      PackUpdated(pack.name!, _createAsset(pack, result.name)));
                   Navigator.of(context).pop(result);
                 }
               },

--- a/app/lib/dialogs/packs/styles/view.dart
+++ b/app/lib/dialogs/packs/styles/view.dart
@@ -88,8 +88,7 @@ class StylesPackView extends StatelessWidget {
                   ),
                 );
                 if (result != true) return;
-                value.setStyle(styleSheet);
-                onChanged(value);
+                onChanged(value.setStyle(styleSheet));
               },
               icon: const PhosphorIcon(PhosphorIconsLight.plus),
               label: Text(AppLocalizations.of(context).create),

--- a/app/lib/dialogs/packs/styles/view.dart
+++ b/app/lib/dialogs/packs/styles/view.dart
@@ -35,8 +35,7 @@ class StylesPackView extends StatelessWidget {
                       (e) => Dismissible(
                         key: ValueKey(e),
                         onDismissed: (direction) {
-                          value.removeStyle(e);
-                          onChanged(value);
+                          onChanged(value.removeStyle(e));
                         },
                         child: ListTile(
                           title: Text(e),
@@ -56,14 +55,12 @@ class StylesPackView extends StatelessWidget {
                               ),
                             );
                             if (result != true) return;
-                            value.setStyle(styleSheet!);
-                            onChanged(value);
+                            onChanged(value.setStyle(styleSheet!));
                           },
                           trailing: IconButton(
                             icon: const PhosphorIcon(PhosphorIconsLight.trash),
                             onPressed: () async {
-                              value.removeStyle(e);
-                              onChanged(value);
+                              onChanged(value.removeStyle(e));
                             },
                           ),
                         ),

--- a/app/lib/models/defaults.dart
+++ b/app/lib/models/defaults.dart
@@ -99,11 +99,11 @@ class DocumentDefaults {
     DocumentPage? page,
   }) {
     page ??= createPage();
-    final data = NoteData(Archive());
     final metadata = createMetadata(name: name);
-    data.setMetadata(metadata);
-    data.setPage(page);
-    data.setInfo(createInfo());
+    final data = NoteData(Archive())
+        .setMetadata(metadata)
+        .setPage(page)
+        .setInfo(createInfo());
     return data;
   }
 
@@ -116,11 +116,10 @@ class DocumentDefaults {
   }
 
   static NoteData createPack() {
-    final data = NoteData(Archive());
     final metadata = createMetadata(
       type: NoteFileType.pack,
     );
-    data.setMetadata(metadata);
+    final data = NoteData(Archive()).setMetadata(metadata);
     return data;
   }
 
@@ -128,19 +127,19 @@ class DocumentDefaults {
       {String name = '',
       Uint8List? thumbnail,
       List<Background> backgrounds = const []}) async {
-    final data = NoteData(Archive());
     final metadata = createMetadata(
       type: NoteFileType.template,
       name: name,
     );
-    data.setMetadata(metadata);
     final page = DocumentPage(
       backgrounds: backgrounds,
     );
-    data.setInfo(createInfo(backgrounds.firstOrNull?.defaultColor));
-    data.setPage(page);
-    data.setPack(await getCorePack());
-    if (thumbnail != null) data.setThumbnail(thumbnail);
+    var data = NoteData(Archive())
+        .setMetadata(metadata)
+        .setInfo(createInfo(backgrounds.firstOrNull?.defaultColor))
+        .setPage(page)
+        .setPack(await getCorePack());
+    if (thumbnail != null) data = data.setThumbnail(thumbnail);
     return data;
   }
 

--- a/app/lib/selections/tools/label.dart
+++ b/app/lib/selections/tools/label.dart
@@ -90,8 +90,8 @@ class LabelToolSelection extends ToolSelection<LabelTool> {
                       key: ValueKey(style),
                       background: Container(color: Colors.red),
                       onDismissed: (direction) {
-                        currentPack.removeStyle(style);
-                        bloc.add(PackUpdated(packName, currentPack));
+                        bloc.add(PackUpdated(
+                            packName, currentPack.removeStyle(style)));
                       },
                       child: ListTile(
                         title: Text(style),

--- a/app/lib/selections/tools/stamp.dart
+++ b/app/lib/selections/tools/stamp.dart
@@ -51,8 +51,8 @@ class StampToolSelection extends ToolSelection<StampTool> {
                       key: ValueKey(component),
                       background: Container(color: Colors.red),
                       onDismissed: (direction) {
-                        currentPack.removeComponent(component);
-                        bloc.add(PackUpdated(packName, currentPack));
+                        bloc.add(PackUpdated(
+                            packName, currentPack.removeComponent(component)));
                       },
                       child: ListTile(
                         title: Text(component),

--- a/app/lib/selections/utilities.dart
+++ b/app/lib/selections/utilities.dart
@@ -167,8 +167,9 @@ class _UtilitiesViewState extends State<_UtilitiesView>
                         );
                         if (thumbnail == null) return;
                         final bytes = thumbnail.buffer.asUint8List();
-                        state.data.setThumbnail(bytes);
-                        state.save();
+                        context
+                            .read<DocumentBloc>()
+                            .add(ThumbnailCaptured(bytes));
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(

--- a/app/lib/services/asset.dart
+++ b/app/lib/services/asset.dart
@@ -23,7 +23,8 @@ class AssetService {
     return image.clone();
   }
 
-  void removeImage(String path) {
-    _images.remove(path)?.dispose();
+  void dispose() {
+    _images.forEach((key, value) => value.dispose());
+    _images.clear();
   }
 }

--- a/app/lib/services/import.dart
+++ b/app/lib/services/import.dart
@@ -170,7 +170,9 @@ class ImportService {
     String loadAsset(Uri source, String fileExtension) {
       final data = source.data?.contentAsBytes();
       if (data == null) return source.toString();
-      return document.addImage(data, fileExtension);
+      final result = document.addImage(data, fileExtension);
+      document = result.$1;
+      return result.$2;
     }
 
     final content = page.content
@@ -234,8 +236,7 @@ class ImportService {
       String dataPath;
       if (newBytes == null) return null;
       final newData = newBytes.buffer.asUint8List();
-      final assetPath = document.addImage(newData, 'png');
-      dataPath = Uri.file(assetPath, windows: false).toString();
+      dataPath = Uri.dataFromBytes(newData).toString();
       final height = image.height.toDouble(), width = image.width.toDouble();
       image.dispose();
       final settingsScale = getSettingsCubit().state.imageScale;
@@ -282,8 +283,7 @@ class ImportService {
         final state = _getState();
         String dataPath;
         if (state != null) {
-          final assetPath = state.data.addImage(bytes, 'svg');
-          dataPath = Uri.file(assetPath, windows: false).toString();
+          dataPath = Uri.dataFromBytes(bytes).toString();
         } else {
           dataPath = UriData.fromBytes(
             bytes,
@@ -385,8 +385,7 @@ class ImportService {
           final scale = 1 / callback.quality;
           final height = page.height;
           final width = page.width;
-          final assetPath = document.addImage(png, 'png');
-          final dataPath = Uri.file(assetPath, windows: false).toString();
+          final dataPath = Uri.dataFromBytes(png).toString();
           selectedElements.add(ImageElement(
               height: height.toDouble(),
               width: width.toDouble(),
@@ -490,7 +489,7 @@ class ImportService {
       content: [...page.content, ...elements],
       areas: [...page.areas, ...areas],
     );
-    document.setPage(page);
+    document = document.setPage(page);
     return document;
   }
 }

--- a/app/lib/views/components.dart
+++ b/app/lib/views/components.dart
@@ -37,67 +37,64 @@ class _ComponentsViewState extends State<ComponentsView> {
       builder: (context, state) {
         if (state is! DocumentLoadSuccess) return const SizedBox.shrink();
         return BlocBuilder<CurrentIndexCubit, CurrentIndex>(
-            buildWhen: (previous, current) =>
-                previous.temporaryHandler != current.temporaryHandler,
-            builder: (context, currentIndex) => StreamBuilder<NoteData>(
-                stream: state.data.onChange,
-                builder: (context, snapshot) {
-                  if (!snapshot.hasData) return const SizedBox.shrink();
-                  final data = snapshot.data!;
-                  final pack =
-                      currentPack == null ? null : data.getPack(currentPack!);
-                  final handler = currentIndex.temporaryHandler;
-                  return Column(
-                    children: [
-                      const SizedBox(height: 8),
-                      DropdownMenu(
-                        dropdownMenuEntries: data
-                            .getPacks()
-                            .map((e) => DropdownMenuEntry(
-                                  value: e,
-                                  label: e,
-                                ))
-                            .toList(),
-                        onSelected: (value) =>
-                            setState(() => currentPack = value),
-                        initialSelection: currentPack,
-                        label: Text(AppLocalizations.of(context).pack),
-                      ),
-                      const SizedBox(height: 8),
-                      Expanded(
-                        child: Material(
-                          color: Colors.transparent,
-                          child: Wrap(
-                            children: pack
-                                    ?.getComponents()
-                                    .map((e) {
-                                      final component = pack.getComponent(e);
-                                      if (component == null) return null;
-                                      return (e, component);
-                                    })
-                                    .whereNotNull()
-                                    .map((e) {
-                                      final location = PackAssetLocation(
-                                        currentPack!,
-                                        e.$1,
-                                      );
-                                      return _ComponentCard(
-                                        component: e.$2,
-                                        pack: pack,
-                                        selected: handler is StampHandler &&
-                                            handler.data.component == location,
-                                        location: location,
-                                        key: ValueKey(e.$1),
-                                      );
-                                    })
-                                    .toList() ??
-                                [],
-                          ),
-                        ),
-                      ),
-                    ],
-                  );
-                }));
+          buildWhen: (previous, current) =>
+              previous.temporaryHandler != current.temporaryHandler,
+          builder: (context, currentIndex) {
+            final data = state.data;
+            final pack =
+                currentPack == null ? null : data.getPack(currentPack!);
+            final handler = currentIndex.temporaryHandler;
+            return Column(
+              children: [
+                const SizedBox(height: 8),
+                DropdownMenu(
+                  dropdownMenuEntries: data
+                      .getPacks()
+                      .map((e) => DropdownMenuEntry(
+                            value: e,
+                            label: e,
+                          ))
+                      .toList(),
+                  onSelected: (value) => setState(() => currentPack = value),
+                  initialSelection: currentPack,
+                  label: Text(AppLocalizations.of(context).pack),
+                ),
+                const SizedBox(height: 8),
+                Expanded(
+                  child: Material(
+                    color: Colors.transparent,
+                    child: Wrap(
+                      children: pack
+                              ?.getComponents()
+                              .map((e) {
+                                final component = pack.getComponent(e);
+                                if (component == null) return null;
+                                return (e, component);
+                              })
+                              .whereNotNull()
+                              .map((e) {
+                                final location = PackAssetLocation(
+                                  currentPack!,
+                                  e.$1,
+                                );
+                                return _ComponentCard(
+                                  component: e.$2,
+                                  pack: pack,
+                                  selected: handler is StampHandler &&
+                                      handler.data.component == location,
+                                  location: location,
+                                  key: ValueKey(e.$1),
+                                );
+                              })
+                              .toList() ??
+                          [],
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        );
       },
     );
   }

--- a/app/lib/views/layers.dart
+++ b/app/lib/views/layers.dart
@@ -19,124 +19,118 @@ class LayersView extends StatelessWidget {
           previous is DocumentLoadSuccess &&
           current is DocumentLoadSuccess &&
           (previous.currentLayer != current.currentLayer ||
-              previous.invisibleLayers != current.invisibleLayers),
+              previous.invisibleLayers != current.invisibleLayers ||
+              previous.page.content != current.page.content),
       builder: (context, state) {
         if (state is! DocumentLoadSuccess) return const SizedBox.shrink();
         final currentLayer = state.currentLayer;
-        return StreamBuilder<NoteData>(
-            stream: state.data.onChange,
-            builder: (context, snapshot) {
-              if (!snapshot.hasData) return const SizedBox.shrink();
-              var layers = (state.page.content.map((e) => e.layer).toSet()
-                    ..add(currentLayer)
-                    ..remove(''))
-                  .toList();
-              return Stack(
-                children: [
-                  ListView(children: [
-                    ListTile(
-                        onTap: () {
+        var layers = (state.page.content.map((e) => e.layer).toSet()
+              ..add(currentLayer)
+              ..remove(''))
+            .toList();
+        return Stack(
+          children: [
+            ListView(children: [
+              ListTile(
+                  onTap: () {
+                    context
+                        .read<DocumentBloc>()
+                        .add(const CurrentLayerChanged(''));
+                  },
+                  selected: state.currentLayer.isEmpty,
+                  leading: IconButton(
+                    icon: PhosphorIcon(state.isLayerVisible('')
+                        ? PhosphorIconsLight.eye
+                        : PhosphorIconsLight.eyeSlash),
+                    onPressed: () {
+                      context
+                          .read<DocumentBloc>()
+                          .add(const LayerVisibilityChanged(''));
+                    },
+                  ),
+                  trailing: IconButton(
+                    icon: const PhosphorIcon(PhosphorIconsLight.pencil),
+                    tooltip: AppLocalizations.of(context).rename,
+                    onPressed: () async {
+                      final bloc = context.read<DocumentBloc>();
+                      final result = await showDialog<String>(
+                          builder: (context) => NameDialog(), context: context);
+                      if (result == null) return;
+                      bloc.add(LayerRenamed(state.currentLayer, result));
+                    },
+                  ),
+                  title: Text(AppLocalizations.of(context).defaultLayer)),
+              const Divider(),
+              ListView.builder(
+                  physics: const NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  itemCount: layers.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    final layer = layers[index];
+                    return EditableListTile(
+                      initialValue: layer,
+                      selected: layer == currentLayer,
+                      onTap: () => context
+                          .read<DocumentBloc>()
+                          .add(CurrentLayerChanged(layer)),
+                      leading: IconButton(
+                        icon: PhosphorIcon(state.isLayerVisible(layer)
+                            ? PhosphorIconsLight.eye
+                            : PhosphorIconsLight.eyeSlash),
+                        onPressed: () {
                           context
                               .read<DocumentBloc>()
-                              .add(const CurrentLayerChanged(''));
+                              .add(LayerVisibilityChanged(layers[index]));
                         },
-                        selected: state.currentLayer.isEmpty,
-                        leading: IconButton(
-                          icon: PhosphorIcon(state.isLayerVisible('')
-                              ? PhosphorIconsLight.eye
-                              : PhosphorIconsLight.eyeSlash),
-                          onPressed: () {
-                            context
-                                .read<DocumentBloc>()
-                                .add(const LayerVisibilityChanged(''));
-                          },
-                        ),
-                        trailing: IconButton(
-                          icon: const PhosphorIcon(PhosphorIconsLight.pencil),
-                          tooltip: AppLocalizations.of(context).rename,
-                          onPressed: () async {
-                            final bloc = context.read<DocumentBloc>();
-                            final result = await showDialog<String>(
-                                builder: (context) => NameDialog(),
-                                context: context);
-                            if (result == null) return;
-                            bloc.add(LayerRenamed(state.currentLayer, result));
-                          },
-                        ),
-                        title: Text(AppLocalizations.of(context).defaultLayer)),
-                    const Divider(),
-                    ListView.builder(
-                        physics: const NeverScrollableScrollPhysics(),
-                        shrinkWrap: true,
-                        itemCount: layers.length,
-                        itemBuilder: (BuildContext context, int index) {
-                          final layer = layers[index];
-                          return EditableListTile(
-                            initialValue: layer,
-                            selected: layer == currentLayer,
-                            onTap: () => context
-                                .read<DocumentBloc>()
-                                .add(CurrentLayerChanged(layer)),
-                            leading: IconButton(
-                              icon: PhosphorIcon(state.isLayerVisible(layer)
-                                  ? PhosphorIconsLight.eye
-                                  : PhosphorIconsLight.eyeSlash),
-                              onPressed: () {
-                                context
-                                    .read<DocumentBloc>()
-                                    .add(LayerVisibilityChanged(layers[index]));
-                              },
-                            ),
-                            onSaved: (value) => context
-                                .read<DocumentBloc>()
-                                .add(LayerRenamed(layer, value)),
-                            actions: [
-                              MenuItemButton(
-                                leadingIcon: const PhosphorIcon(
-                                    PhosphorIconsLight.trash),
-                                onPressed: currentLayer == layer
-                                    ? null
-                                    : () async {
-                                        final result = await showDialog<bool>(
-                                            context: context,
-                                            builder: (context) =>
-                                                const DeleteDialog());
-                                        if (result != true) return;
-                                        snapshot.data?.removePage(layer);
-                                      },
-                                child:
-                                    Text(AppLocalizations.of(context).delete),
-                              )
-                            ],
-                          );
-                        }),
-                  ]),
-                  Align(
-                    alignment: Alignment.bottomCenter,
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: FloatingActionButton.extended(
-                          label: Text(
-                              AppLocalizations.of(context).selectCustomLayer),
-                          icon:
-                              const PhosphorIcon(PhosphorIconsLight.selection),
-                          onPressed: () async {
-                            final bloc = context.read<DocumentBloc>();
-                            final state = bloc.state;
-                            if (state is! DocumentLoadSuccess) return;
-                            final result = await showDialog<String>(
-                                builder: (context) => NameDialog(
-                                      value: state.currentLayer,
-                                    ),
-                                context: context);
-                            if (result == null) return;
-                            bloc.add(CurrentLayerChanged(result));
-                          }),
-                    ),
-                  )
-                ],
-              );
-            });
+                      ),
+                      onSaved: (value) => context
+                          .read<DocumentBloc>()
+                          .add(LayerRenamed(layer, value)),
+                      actions: [
+                        MenuItemButton(
+                          leadingIcon:
+                              const PhosphorIcon(PhosphorIconsLight.trash),
+                          onPressed: currentLayer == layer
+                              ? null
+                              : () async {
+                                  final result = await showDialog<bool>(
+                                      context: context,
+                                      builder: (context) =>
+                                          const DeleteDialog());
+                                  if (result != true) return;
+                                  context
+                                      .read<DocumentBloc>()
+                                      .add(LayerRemoved(layer));
+                                },
+                          child: Text(AppLocalizations.of(context).delete),
+                        )
+                      ],
+                    );
+                  }),
+            ]),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: FloatingActionButton.extended(
+                    label: Text(AppLocalizations.of(context).selectCustomLayer),
+                    icon: const PhosphorIcon(PhosphorIconsLight.selection),
+                    onPressed: () async {
+                      final bloc = context.read<DocumentBloc>();
+                      final state = bloc.state;
+                      if (state is! DocumentLoadSuccess) return;
+                      final result = await showDialog<String>(
+                          builder: (context) => NameDialog(
+                                value: state.currentLayer,
+                              ),
+                          context: context);
+                      if (result == null) return;
+                      bloc.add(CurrentLayerChanged(result));
+                    }),
+              ),
+            )
+          ],
+        );
       },
     );
   }

--- a/app/lib/views/main.dart
+++ b/app/lib/views/main.dart
@@ -244,6 +244,7 @@ class _ProjectPageState extends State<ProjectPage> {
     super.dispose();
     widget.embedding?.handler.unregister();
     _closeSubscription.dispose();
+    _bloc?.dispose();
   }
 
   @override

--- a/app/lib/views/toolbars/color.dart
+++ b/app/lib/views/toolbars/color.dart
@@ -107,9 +107,8 @@ class _ColorToolbarViewState extends State<ColorToolbarView> {
                                   colors: List<int>.from(palette.colors)
                                     ..removeAt(index),
                                 );
-                                pack?.setPalette(palette!);
-                                bloc.add(
-                                    PackUpdated(colorPalette!.pack, pack!));
+                                bloc.add(PackUpdated(colorPalette!.pack,
+                                    pack!.setPalette(palette!)));
                               },
                             );
                           }),

--- a/app/lib/views/toolbars/components.dart
+++ b/app/lib/views/toolbars/components.dart
@@ -48,85 +48,79 @@ class _ComponentsToolbarViewState extends State<ComponentsToolbarView> {
   Widget build(BuildContext context) {
     final state = context.read<DocumentBloc>().state;
     if (state is! DocumentLoadSuccess) return const SizedBox.shrink();
-    return StreamBuilder<NoteData>(
-        stream: state.data.onChange,
-        builder: (context, snapshot) {
-          if (!snapshot.hasData) return const SizedBox.shrink();
-          final bloc = context.read<DocumentBloc>();
-          final document = snapshot.data!;
+    final bloc = context.read<DocumentBloc>();
+    final document = state.data;
 
-          final component = widget.component.resolveComponent(document);
-          final pack = document.getPack(currentPack);
-          final components = pack
-                  ?.getComponents()
-                  .map((e) {
-                    final component = pack.getComponent(e);
-                    if (component == null) return null;
-                    return (e, component);
-                  })
-                  .whereNotNull()
-                  .toList() ??
-              [];
-          return Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              if (currentPack != widget.component.pack &&
-                  component != null) ...[
-                _ComponentsButton(
-                  component: widget.component,
-                  valueLocation: widget.component,
-                  value: component,
-                  bloc: bloc,
-                  pack: pack,
-                  onChanged: () {},
-                ),
-                const VerticalDivider(),
-              ],
-              Expanded(
-                  child: Scrollbar(
-                controller: _scrollController,
-                child: ListView(
-                    controller: _scrollController,
-                    scrollDirection: Axis.horizontal,
-                    children: [
-                      ...List.generate(components.length, (index) {
-                        final current = components[index];
-                        final location = PackAssetLocation(
-                          currentPack,
-                          current.$1,
-                        );
-                        return _ComponentsButton(
-                          bloc: bloc,
-                          component: widget.component,
-                          value: current.$2,
-                          valueLocation: location,
-                          pack: pack,
-                          onChanged: () {
-                            widget.onChanged(location);
-                          },
-                        );
-                      }),
-                    ]),
-              )),
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: MenuAnchor(
-                  builder: defaultMenuButton(),
-                  menuChildren: document
-                      .getPacks()
-                      .map((e) => RadioMenuButton(
-                          value: e,
-                          groupValue: currentPack,
-                          onChanged: (value) =>
-                              setState(() => currentPack = value ?? e),
-                          child: Text(e)))
-                      .toList(),
-                ),
-              ),
-            ],
-          );
-        });
+    final component = widget.component.resolveComponent(document);
+    final pack = document.getPack(currentPack);
+    final components = pack
+            ?.getComponents()
+            .map((e) {
+              final component = pack.getComponent(e);
+              if (component == null) return null;
+              return (e, component);
+            })
+            .whereNotNull()
+            .toList() ??
+        [];
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (currentPack != widget.component.pack && component != null) ...[
+          _ComponentsButton(
+            component: widget.component,
+            valueLocation: widget.component,
+            value: component,
+            bloc: bloc,
+            pack: pack,
+            onChanged: () {},
+          ),
+          const VerticalDivider(),
+        ],
+        Expanded(
+            child: Scrollbar(
+          controller: _scrollController,
+          child: ListView(
+              controller: _scrollController,
+              scrollDirection: Axis.horizontal,
+              children: [
+                ...List.generate(components.length, (index) {
+                  final current = components[index];
+                  final location = PackAssetLocation(
+                    currentPack,
+                    current.$1,
+                  );
+                  return _ComponentsButton(
+                    bloc: bloc,
+                    component: widget.component,
+                    value: current.$2,
+                    valueLocation: location,
+                    pack: pack,
+                    onChanged: () {
+                      widget.onChanged(location);
+                    },
+                  );
+                }),
+              ]),
+        )),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: MenuAnchor(
+            builder: defaultMenuButton(),
+            menuChildren: document
+                .getPacks()
+                .map((e) => RadioMenuButton(
+                    value: e,
+                    groupValue: currentPack,
+                    onChanged: (value) =>
+                        setState(() => currentPack = value ?? e),
+                    child: Text(e)))
+                .toList(),
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/fastlane/metadata/android/en-US/changelogs/72.txt
+++ b/fastlane/metadata/android/en-US/changelogs/72.txt
@@ -50,6 +50,7 @@
 * Fix template creation message text
 * Fix page ordering
 * Fix packs dialog closes after action
+* Fix layer remove button not working
 * Disable gestures on mouse input
 * Remove view options from undo
 * Remove reload after clicking on star

--- a/fastlane/metadata/android/en-US/changelogs/72.txt
+++ b/fastlane/metadata/android/en-US/changelogs/72.txt
@@ -49,6 +49,7 @@
 * Fix duplication position issues
 * Fix template creation message text
 * Fix page ordering
+* Fix page index when renaming
 * Fix packs dialog closes after action
 * Fix layer remove button not working
 * Disable gestures on mouse input


### PR DESCRIPTION
To allow undo/redo file changes, we need to track which files was added and removed.
Currently undo/redo importing images does not work.
This pull request will fix this
Now `NoteData` is immutable