### PR TITLE
Change ZIP export button label for clarity

### DIFF
--- a/app/lib/l10n/app_af.arb
+++ b/app/lib/l10n/app_af.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Export",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -652,6 +652,7 @@
   "flipVertical": "قلب عمودي",
   "grayscale": "Grayscale",
   "moveOnGesture": "تحريك على الإيماءة",
+  "exportAllFiles": "تصدير",
   "restoreSettingsFromFile": "استعادة الإعدادات من الملف",
   "exportSettingsToFile": "تصدير الإعدادات إلى ملف"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Exportar",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Překlopit svisle",
   "grayscale": "Grayscale",
   "moveOnGesture": "Přesunout gestem",
+  "exportAllFiles": "Exportovat",
   "restoreSettingsFromFile": "Obnovit nastavení ze souboru",
   "exportSettingsToFile": "Exportovat nastavení do souboru"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Vend lodret",
   "grayscale": "Grayscale",
   "moveOnGesture": "Flyt på bevægelse",
+  "exportAllFiles": "Eksporter",
   "restoreSettingsFromFile": "Gendan indstillinger fra fil",
   "exportSettingsToFile": "Eksporter indstillinger til fil"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Vertikal spiegeln",
   "grayscale": "Grayscale",
   "moveOnGesture": "Geste verschieben",
+  "exportAllFiles": "Exportieren",
   "restoreSettingsFromFile": "Einstellungen aus Datei wiederherstellen",
   "exportSettingsToFile": "Einstellungen in Datei exportieren"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Κάθετη αναστροφή",
   "grayscale": "Grayscale",
   "moveOnGesture": "Μετακίνηση στη χειρονομία",
+  "exportAllFiles": "Εξαγωγή",
   "restoreSettingsFromFile": "Επαναφορά ρυθμίσεων από αρχείο",
   "exportSettingsToFile": "Εξαγωγή ρυθμίσεων σε αρχείο"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Export all files",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Voltear vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Mover en gesto",
+  "exportAllFiles": "Exportar",
   "restoreSettingsFromFile": "Restaurar ajustes desde el archivo",
   "exportSettingsToFile": "Exportar ajustes al archivo"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Käännä pystysuuntainen",
   "grayscale": "Grayscale",
   "moveOnGesture": "Siirrä ele",
+  "exportAllFiles": "Vie",
   "restoreSettingsFromFile": "Palauta asetukset tiedostosta",
   "exportSettingsToFile": "Vie asetukset tiedostoon"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Retourner verticalement",
   "grayscale": "Grayscale",
   "moveOnGesture": "Geste de déplacement",
+  "exportAllFiles": "Exportation",
   "restoreSettingsFromFile": "Restaurer les paramètres à partir du fichier",
   "exportSettingsToFile": "Exporter les paramètres vers un fichier"
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Export",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Export",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Exportálás",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Capovolgi verticale",
   "grayscale": "Grayscale",
   "moveOnGesture": "Sposta al gesto",
+  "exportAllFiles": "Esporta",
   "restoreSettingsFromFile": "Ripristina le impostazioni dal file",
   "exportSettingsToFile": "Esporta le impostazioni su file"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -652,6 +652,7 @@
   "flipVertical": "垂直方向に反転",
   "grayscale": "Grayscale",
   "moveOnGesture": "ジェスチャー上に移動",
+  "exportAllFiles": "エクスポート",
   "restoreSettingsFromFile": "設定をファイルから復元",
   "exportSettingsToFile": "設定をファイルにエクスポート"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Export",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Spiegel verticaal",
   "grayscale": "Grayscale",
   "moveOnGesture": "Verplaats naar gebaar",
+  "exportAllFiles": "Exporteren",
   "restoreSettingsFromFile": "Instellingen herstellen vanuit bestand",
   "exportSettingsToFile": "Instellingen exporteren naar bestand"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Vend vertikalt",
   "grayscale": "Grayscale",
   "moveOnGesture": "Flytt på bevegelse",
+  "exportAllFiles": "Eksporter",
   "restoreSettingsFromFile": "Gjenopprett innstillinger fra fil",
   "exportSettingsToFile": "Eksporter innstillinger til fil"
 }

--- a/app/lib/l10n/app_or.arb
+++ b/app/lib/l10n/app_or.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Export",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Odwróć w pionie",
   "grayscale": "Grayscale",
   "moveOnGesture": "Przesuń po gestach",
+  "exportAllFiles": "Eksportuj",
   "restoreSettingsFromFile": "Przywróć ustawienia z pliku",
   "exportSettingsToFile": "Eksportuj ustawienia do pliku"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Inverter verticalmente",
   "grayscale": "Grayscale",
   "moveOnGesture": "Mover para gesto",
+  "exportAllFiles": "Exportação",
   "restoreSettingsFromFile": "Restaurar configurações do arquivo",
   "exportSettingsToFile": "Exportar configurações para arquivo"
 }

--- a/app/lib/l10n/app_pt_BR.arb
+++ b/app/lib/l10n/app_pt_BR.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Inverter verticalmente",
   "grayscale": "Grayscale",
   "moveOnGesture": "Mover para gesto",
+  "exportAllFiles": "Exportar",
   "restoreSettingsFromFile": "Restaurar configurações do arquivo",
   "exportSettingsToFile": "Exportar configurações para arquivo"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Întoarce vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Mută la gest",
+  "exportAllFiles": "Exportă",
   "restoreSettingsFromFile": "Restabilește setările din fișier",
   "exportSettingsToFile": "Exportă setările în fișier"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Отразить вертикально",
   "grayscale": "Grayscale",
   "moveOnGesture": "Переместить жест",
+  "exportAllFiles": "Экспорт",
   "restoreSettingsFromFile": "Восстановить настройки из файла",
   "exportSettingsToFile": "Экспорт настроек в файл"
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Export",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Vänd vertikalt",
   "grayscale": "Grayscale",
   "moveOnGesture": "Flytta på gest",
+  "exportAllFiles": "Exportera",
   "restoreSettingsFromFile": "Återställ inställningar från fil",
   "exportSettingsToFile": "Exportera inställningar till fil"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "ส่งออก",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Dışa Aktar",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Віддзеркалити вертикально",
   "grayscale": "Grayscale",
   "moveOnGesture": "Перемістити жест",
+  "exportAllFiles": "Експорт",
   "restoreSettingsFromFile": "Відновити налаштування з файлу",
   "exportSettingsToFile": "Експорт налаштувань у файл"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "Xuất dữ liệu",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_zh-Hant.arb
+++ b/app/lib/l10n/app_zh-Hant.arb
@@ -652,6 +652,7 @@
   "flipVertical": "Flip vertical",
   "grayscale": "Grayscale",
   "moveOnGesture": "Move on gesture",
+  "exportAllFiles": "匯出",
   "restoreSettingsFromFile": "Restore settings from file",
   "exportSettingsToFile": "Export settings to file"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -652,6 +652,7 @@
   "flipVertical": "垂直翻转",
   "grayscale": "Grayscale",
   "moveOnGesture": "手势移动",
+  "exportAllFiles": "导出",
   "restoreSettingsFromFile": "从文件恢复设置",
   "exportSettingsToFile": "导出设置到文件"
 }

--- a/app/lib/settings/data.dart
+++ b/app/lib/settings/data.dart
@@ -134,7 +134,8 @@ class _DataSettingsPageState extends State<DataSettingsPage> {
                         ),
                       ),
                       ListTile(
-                        title: Text(AppLocalizations.of(context).exportAllFiles),
+                        title:
+                            Text(AppLocalizations.of(context).exportAllFiles),
                         leading: const PhosphorIcon(PhosphorIconsLight.export),
                         onTap: () async {
                           final directory = await _documentSystem.fileSystem

--- a/app/lib/settings/data.dart
+++ b/app/lib/settings/data.dart
@@ -134,7 +134,7 @@ class _DataSettingsPageState extends State<DataSettingsPage> {
                         ),
                       ),
                       ListTile(
-                        title: Text(AppLocalizations.of(context).export),
+                        title: Text(AppLocalizations.of(context).exportAllFiles),
                         leading: const PhosphorIcon(PhosphorIconsLight.export),
                         onTap: () async {
                           final directory = await _documentSystem.fileSystem


### PR DESCRIPTION
Currently, it is not very clear what exactly the Export button under Settings -> Data will export. As a new user, I assumed this would export _everything_ in the app (like a database dump), including files, templates, and settings. However, after doing some testing and looking at the code, it appears to only export files.

In order to reduce confusion, this PR changes the label of the Export button to "Export all files". This makes it more obvious that the output will include all files and nothing else.

I created a new translation key for this called `exportAllFiles`, in order to not affect other places where the word "Export" is used. English is the only language that I am confident in, so for all other languages, I simply copied each language's value for `export`, so the button will not change for any other language besides English.

### Screenshots
<details>
<summary>English</summary>

![image](https://github.com/user-attachments/assets/80fbdcd0-01e3-44b7-a39c-54a5327fbb35)

</details>

<details>
<summary>Español (no change)</summary>

![image](https://github.com/user-attachments/assets/6bc91308-2496-4f2b-9731-920c4f51d18c)

</details>