### PR TITLE
Add document titles to file list views

### DIFF
--- a/app/lib/views/files/list.dart
+++ b/app/lib/views/files/list.dart
@@ -47,6 +47,18 @@ class FileEntityListTile extends StatelessWidget {
     required this.actionButton,
   });
 
+  String getDocumentName(BuildContext context) {
+    if (entity is FileSystemFile<NoteFile>) {
+      final noteFile = (entity as FileSystemFile<NoteFile>);
+      final NoteData? data = noteFile.data?.load();
+      final FileMetadata? metadata = data?.getMetadata();
+      if (metadata != null && metadata.name != '') {
+        return metadata.name;
+      }
+    }
+    return AppLocalizations.of(context).untitled;
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = ColorScheme.of(context);
@@ -219,15 +231,25 @@ class FileEntityListTile extends StatelessWidget {
                                         mainAxisSize: MainAxisSize.min,
                                         children: [
                                           Text(
-                                            entity.fileName,
+                                            getDocumentName(context),
                                             maxLines: 1,
                                             overflow: TextOverflow.ellipsis,
                                             style: TextTheme.of(
                                               context,
                                             ).labelLarge,
                                           ),
+                                          const SizedBox(height: 1.5),
+                                          Text(
+                                            entity.fileName,
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: TextTheme.of(context)
+                                                .bodySmall
+                                                ?.copyWith(
+                                                    color: colorScheme.outline),
+                                          ),
                                           if (!isDesktop && !collapsed) ...[
-                                            const SizedBox(height: 6),
+                                            const SizedBox(height: 3),
                                             Wrap(spacing: 4, children: info),
                                           ],
                                         ],


### PR DESCRIPTION
(This entire change is based on the assumption that file names are _not_ always supposed to automatically update when their document title is changed. If file names _are_ always supposed to match their document title, then feel free to reject this and I can instead investigate why re-naming a document doesn't always rename the file.)

As document titles start to deviate from their file names, it can become difficult to find the file you want. This is especially true if you have a lot of documents that started off with the default date filename, like `2025-03-19.bfly`, which you then re-titled later. Additionally, because the recent files area uses document titles, but the file list view uses file names, it can be confusing for new users to understand that an item in the recent files section and an item in the list view may be referencing the same file, even though they have completely different names.

To resolve these issues, this change adds document titles to file list views. Document titles are displayed as the primary identifier, and file names are displayed secondarily, because I think document titles have a better chance of being "pretty" and formatted the way the user expects.

This has been tested on Android and web.

⚠️ This change introduces a minor papercut where the user may think that the rename/pencil button would change the document title instead of the file name. However, it should be immediately apparent when they begin editing that they are actually editing the file name, so I don't think this is a big issue, and I think it is a fine trade-off for a better file browsing experience. The differentiation of document titles and file names was a stumbling block for me as a new user, so I think the best long-term solution may be a unification of document titles and file names (either making file names internally-managed and not visible to the user, or doing away with document titles), but that's a bigger discussion...

![android_home_landscape](https://github.com/user-attachments/assets/bd8a0072-5174-431f-93fc-0e64f188e7de)

### More screenshots

<details>
<summary>Android: Home (Portrait)</summary>

![android_home_portrait](https://github.com/user-attachments/assets/c92cea0d-04a5-4a17-aaaa-2521e7566f1f)

</details>

<details>
<summary>Android: Sidebar</summary>

![android_sidebar](https://github.com/user-attachments/assets/35b19ccc-46d9-499e-abe5-675dfde123a3)

</details>

<details>
<summary>Web: Home</summary>

![web](https://github.com/user-attachments/assets/c8986f8d-2b6f-4671-842f-c5d23c522892)

</details>

<details>
<summary>Web: Sidebar</summary>

![web_sidebar](https://github.com/user-attachments/assets/713dc853-b456-4399-a81b-cf02bde07f83)

</details>

<details>
<summary>Web: Tiny</summary>

![web_tiny](https://github.com/user-attachments/assets/4da45f2a-394a-4112-9bd2-f12eed2c19ff)

</details>