### PR TITLE
Fix file list not refreshing when returning to home screen

### DIFF
--- a/app/lib/services/import.dart
+++ b/app/lib/services/import.dart
@@ -441,7 +441,8 @@ class ImportService {
       final state = _getState();
       if (newBytes == null) return null;
       final newData = newBytes.buffer.asUint8List();
-      final dataPath = Uri.dataFromBytes(newData, mimeType: 'image/png').toString();
+      final dataPath =
+          Uri.dataFromBytes(newData, mimeType: 'image/png').toString();
       final height = image.height.toDouble(), width = image.width.toDouble();
       image.dispose();
       final settingsScale = getSettingsCubit().state.imageScale;

--- a/app/lib/views/home/page.dart
+++ b/app/lib/views/home/page.dart
@@ -215,6 +215,7 @@ class _HomePageState extends State<HomePage> {
                                           activeAsset: widget.selectedAsset,
                                           remote: _remote,
                                           isMobile: false,
+                                          key: _filesViewKey,
                                           onRemoteChanged: (value) =>
                                               updateRemote(value),
                                         ),


### PR DESCRIPTION
Fixes an issue where (when using the desktop layout) the file list would not refresh after returning to the home screen.

Previously, `_filesViewKey.currentState?.reloadFileSystem()` was being called when returning to the homescreen, but the desktop layout's FileList did not have its `key` attribute set, so `_filesViewKey.currentState?` was always null.

(Also includes an unrelated code formatting fix in a file that was modified for the Swamp experiment, so the formatting check doesn't fail)

Closes #813 