### PR TITLE
Add ability to replace waypoints

### DIFF
--- a/api/lib/src/helpers/search.dart
+++ b/api/lib/src/helpers/search.dart
@@ -85,7 +85,7 @@ extension AreaSearchHelper on Area {
 
 extension WaypointSearchHelper on Waypoint {
   WaypointResult? matches(Pattern query) {
-    if (!name.contains(query)) return null;
+    if (name != null && name!.contains(query)) return null;
     return WaypointResult(
       this,
       '',

--- a/api/lib/src/models/page.dart
+++ b/api/lib/src/models/page.dart
@@ -89,7 +89,7 @@ sealed class DocumentPage with _$DocumentPage {
   }
 
   Waypoint getOriginWaypoint() {
-    return getWaypointByName(null) ?? Waypoint.defaultOrigin;
+    return getWaypointByName(Waypoint.originName) ?? Waypoint.defaultOrigin;
   }
 }
 

--- a/api/lib/src/models/page.dart
+++ b/api/lib/src/models/page.dart
@@ -82,6 +82,15 @@ sealed class DocumentPage with _$DocumentPage {
       return copyWith(layers: newLayers.toList());
     });
   }
+
+  Waypoint getOriginWaypoint() {
+    int customOriginIndex = waypoints.indexWhere((waypoint) => waypoint.name == Waypoint.customOriginName);
+    if (customOriginIndex != -1) {
+      return waypoints[customOriginIndex];
+    } else {
+      return Waypoint.defaultOrigin;
+    }
+  }
 }
 
 @freezed

--- a/api/lib/src/models/page.dart
+++ b/api/lib/src/models/page.dart
@@ -83,19 +83,13 @@ sealed class DocumentPage with _$DocumentPage {
     });
   }
 
-  Waypoint? getWaypointByName(String waypointName) {
-    int waypointIndex =
-        waypoints.indexWhere((waypoint) => waypoint.name == waypointName);
-    if (waypointIndex != -1) {
-      return waypoints[waypointIndex];
-    } else {
-      return null;
-    }
+  Waypoint? getWaypointByName(String? waypointName) {
+    return waypoints
+        .firstWhereOrNull((waypoint) => waypoint.name == waypointName);
   }
 
   Waypoint getOriginWaypoint() {
-    return getWaypointByName(Waypoint.customOriginName) ??
-        Waypoint.defaultOrigin;
+    return getWaypointByName(null) ?? Waypoint.defaultOrigin;
   }
 }
 

--- a/api/lib/src/models/page.dart
+++ b/api/lib/src/models/page.dart
@@ -83,14 +83,19 @@ sealed class DocumentPage with _$DocumentPage {
     });
   }
 
-  Waypoint getOriginWaypoint() {
-    int customOriginIndex = waypoints
-        .indexWhere((waypoint) => waypoint.name == Waypoint.customOriginName);
-    if (customOriginIndex != -1) {
-      return waypoints[customOriginIndex];
+  Waypoint? getWaypointByName(String waypointName) {
+    int waypointIndex =
+        waypoints.indexWhere((waypoint) => waypoint.name == waypointName);
+    if (waypointIndex != -1) {
+      return waypoints[waypointIndex];
     } else {
-      return Waypoint.defaultOrigin;
+      return null;
     }
+  }
+
+  Waypoint getOriginWaypoint() {
+    return getWaypointByName(Waypoint.customOriginName) ??
+        Waypoint.defaultOrigin;
   }
 }
 

--- a/api/lib/src/models/page.dart
+++ b/api/lib/src/models/page.dart
@@ -84,7 +84,8 @@ sealed class DocumentPage with _$DocumentPage {
   }
 
   Waypoint getOriginWaypoint() {
-    int customOriginIndex = waypoints.indexWhere((waypoint) => waypoint.name == Waypoint.customOriginName);
+    int customOriginIndex = waypoints
+        .indexWhere((waypoint) => waypoint.name == Waypoint.customOriginName);
     if (customOriginIndex != -1) {
       return waypoints[customOriginIndex];
     } else {

--- a/api/lib/src/models/waypoint.dart
+++ b/api/lib/src/models/waypoint.dart
@@ -9,7 +9,7 @@ part 'waypoint.freezed.dart';
 @freezed
 sealed class Waypoint with _$Waypoint {
   static const Waypoint defaultOrigin = Waypoint('', Point(0, 0), 1);
-  static const String customOriginName = "_origin";
+  static const String customOriginName = '_origin';
 
   const factory Waypoint(
       String name, @DoublePointJsonConverter() Point<double> position,

--- a/api/lib/src/models/waypoint.dart
+++ b/api/lib/src/models/waypoint.dart
@@ -8,7 +8,7 @@ part 'waypoint.freezed.dart';
 
 @freezed
 sealed class Waypoint with _$Waypoint {
-  static const Null originName = null;
+  static const String? originName = null;
   static const Waypoint defaultOrigin = Waypoint(originName, Point(0, 0), 1);
 
   const factory Waypoint(

--- a/api/lib/src/models/waypoint.dart
+++ b/api/lib/src/models/waypoint.dart
@@ -8,11 +8,11 @@ part 'waypoint.freezed.dart';
 
 @freezed
 sealed class Waypoint with _$Waypoint {
-  static const Waypoint defaultOrigin = Waypoint('', Point(0, 0), 1);
-  static const String customOriginName = '_origin';
+  static const Null originName = null;
+  static const Waypoint defaultOrigin = Waypoint(originName, Point(0, 0), 1);
 
   const factory Waypoint(
-      String name, @DoublePointJsonConverter() Point<double> position,
+      String? name, @DoublePointJsonConverter() Point<double> position,
       [double? scale]) = _Waypoint;
 
   factory Waypoint.fromJson(Map<String, dynamic> json) =>

--- a/api/lib/src/models/waypoint.dart
+++ b/api/lib/src/models/waypoint.dart
@@ -8,7 +8,8 @@ part 'waypoint.freezed.dart';
 
 @freezed
 sealed class Waypoint with _$Waypoint {
-  static const Waypoint origin = Waypoint('', Point(0, 0), 1);
+  static const Waypoint defaultOrigin = Waypoint('', Point(0, 0), 1);
+  static const String customOriginName = "_origin";
 
   const factory Waypoint(
       String name, @DoublePointJsonConverter() Point<double> position,

--- a/api/lib/src/models/waypoint.freezed.dart
+++ b/api/lib/src/models/waypoint.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$Waypoint {
-  String get name;
+  String? get name;
   @DoublePointJsonConverter()
   Point<double> get position;
   double? get scale;
@@ -57,7 +57,7 @@ abstract mixin class $WaypointCopyWith<$Res> {
       _$WaypointCopyWithImpl;
   @useResult
   $Res call(
-      {String name,
+      {String? name,
       @DoublePointJsonConverter() Point<double> position,
       double? scale});
 }
@@ -74,15 +74,15 @@ class _$WaypointCopyWithImpl<$Res> implements $WaypointCopyWith<$Res> {
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = null,
+    Object? name = freezed,
     Object? position = null,
     Object? scale = freezed,
   }) {
     return _then(_self.copyWith(
-      name: null == name
+      name: freezed == name
           ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       position: null == position
           ? _self.position
           : position // ignore: cast_nullable_to_non_nullable
@@ -104,7 +104,7 @@ class _Waypoint implements Waypoint {
       _$WaypointFromJson(json);
 
   @override
-  final String name;
+  final String? name;
   @override
   @DoublePointJsonConverter()
   final Point<double> position;
@@ -155,7 +155,7 @@ abstract mixin class _$WaypointCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String name,
+      {String? name,
       @DoublePointJsonConverter() Point<double> position,
       double? scale});
 }
@@ -172,15 +172,15 @@ class __$WaypointCopyWithImpl<$Res> implements _$WaypointCopyWith<$Res> {
   @override
   @pragma('vm:prefer-inline')
   $Res call({
-    Object? name = null,
+    Object? name = freezed,
     Object? position = null,
     Object? scale = freezed,
   }) {
     return _then(_Waypoint(
-      null == name
+      freezed == name
           ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       null == position
           ? _self.position
           : position // ignore: cast_nullable_to_non_nullable

--- a/api/lib/src/models/waypoint.g.dart
+++ b/api/lib/src/models/waypoint.g.dart
@@ -7,7 +7,7 @@ part of 'waypoint.dart';
 // **************************************************************************
 
 _Waypoint _$WaypointFromJson(Map json) => _Waypoint(
-      json['name'] as String,
+      json['name'] as String?,
       const DoublePointJsonConverter().fromJson(json['position'] as Map),
       (json['scale'] as num?)?.toDouble(),
     );

--- a/api/lib/src/protocol/event.dart
+++ b/api/lib/src/protocol/event.dart
@@ -97,16 +97,16 @@ sealed class DocumentEvent extends ReplayEvent with _$DocumentEvent {
   ) = WaypointCreated;
 
   const factory DocumentEvent.waypointChanged(
-    String name,
+    String? name,
     Waypoint waypoint,
   ) = WaypointChanged;
 
   const factory DocumentEvent.waypointRemoved(
-    String name,
+    String? name,
   ) = WaypointRemoved;
 
   const factory DocumentEvent.waypointReordered(
-    String name,
+    String? name,
     int newIndex,
   ) = WaypointReordered;
 

--- a/api/lib/src/protocol/event.freezed.dart
+++ b/api/lib/src/protocol/event.freezed.dart
@@ -1918,7 +1918,7 @@ class WaypointChanged extends DocumentEvent {
   factory WaypointChanged.fromJson(Map<String, dynamic> json) =>
       _$WaypointChangedFromJson(json);
 
-  final String name;
+  final String? name;
   final Waypoint waypoint;
 
   @JsonKey(name: 'type')
@@ -1965,7 +1965,7 @@ abstract mixin class $WaypointChangedCopyWith<$Res>
           WaypointChanged value, $Res Function(WaypointChanged) _then) =
       _$WaypointChangedCopyWithImpl;
   @useResult
-  $Res call({String name, Waypoint waypoint});
+  $Res call({String? name, Waypoint waypoint});
 
   $WaypointCopyWith<$Res> get waypoint;
 }
@@ -1982,14 +1982,14 @@ class _$WaypointChangedCopyWithImpl<$Res>
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   $Res call({
-    Object? name = null,
+    Object? name = freezed,
     Object? waypoint = null,
   }) {
     return _then(WaypointChanged(
-      null == name
+      freezed == name
           ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       null == waypoint
           ? _self.waypoint
           : waypoint // ignore: cast_nullable_to_non_nullable
@@ -2017,7 +2017,7 @@ class WaypointRemoved extends DocumentEvent {
   factory WaypointRemoved.fromJson(Map<String, dynamic> json) =>
       _$WaypointRemovedFromJson(json);
 
-  final String name;
+  final String? name;
 
   @JsonKey(name: 'type')
   final String $type;
@@ -2061,7 +2061,7 @@ abstract mixin class $WaypointRemovedCopyWith<$Res>
           WaypointRemoved value, $Res Function(WaypointRemoved) _then) =
       _$WaypointRemovedCopyWithImpl;
   @useResult
-  $Res call({String name});
+  $Res call({String? name});
 }
 
 /// @nodoc
@@ -2076,13 +2076,13 @@ class _$WaypointRemovedCopyWithImpl<$Res>
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   $Res call({
-    Object? name = null,
+    Object? name = freezed,
   }) {
     return _then(WaypointRemoved(
-      null == name
+      freezed == name
           ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
     ));
   }
 }
@@ -2096,7 +2096,7 @@ class WaypointReordered extends DocumentEvent {
   factory WaypointReordered.fromJson(Map<String, dynamic> json) =>
       _$WaypointReorderedFromJson(json);
 
-  final String name;
+  final String? name;
   final int newIndex;
 
   @JsonKey(name: 'type')
@@ -2143,7 +2143,7 @@ abstract mixin class $WaypointReorderedCopyWith<$Res>
           WaypointReordered value, $Res Function(WaypointReordered) _then) =
       _$WaypointReorderedCopyWithImpl;
   @useResult
-  $Res call({String name, int newIndex});
+  $Res call({String? name, int newIndex});
 }
 
 /// @nodoc
@@ -2158,14 +2158,14 @@ class _$WaypointReorderedCopyWithImpl<$Res>
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   $Res call({
-    Object? name = null,
+    Object? name = freezed,
     Object? newIndex = null,
   }) {
     return _then(WaypointReordered(
-      null == name
+      freezed == name
           ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       null == newIndex
           ? _self.newIndex
           : newIndex // ignore: cast_nullable_to_non_nullable

--- a/api/lib/src/protocol/event.g.dart
+++ b/api/lib/src/protocol/event.g.dart
@@ -267,7 +267,7 @@ Map<String, dynamic> _$WaypointCreatedToJson(WaypointCreated instance) =>
     };
 
 WaypointChanged _$WaypointChangedFromJson(Map json) => WaypointChanged(
-      json['name'] as String,
+      json['name'] as String?,
       Waypoint.fromJson(Map<String, dynamic>.from(json['waypoint'] as Map)),
       $type: json['type'] as String?,
     );
@@ -280,7 +280,7 @@ Map<String, dynamic> _$WaypointChangedToJson(WaypointChanged instance) =>
     };
 
 WaypointRemoved _$WaypointRemovedFromJson(Map json) => WaypointRemoved(
-      json['name'] as String,
+      json['name'] as String?,
       $type: json['type'] as String?,
     );
 
@@ -291,7 +291,7 @@ Map<String, dynamic> _$WaypointRemovedToJson(WaypointRemoved instance) =>
     };
 
 WaypointReordered _$WaypointReorderedFromJson(Map json) => WaypointReordered(
-      json['name'] as String,
+      json['name'] as String?,
       (json['newIndex'] as num).toInt(),
       $type: json['type'] as String?,
     );

--- a/app/lib/bloc/document_bloc.dart
+++ b/app/lib/bloc/document_bloc.dart
@@ -509,17 +509,28 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
       if (!(current.embedding?.editable ?? true)) return;
-      return _saveState(
-        emit,
-        state: current.copyWith(
-            page: current.page.copyWith(
-                waypoints: current.page.waypoints.map((e) {
-          if (e.name == event.name) {
-            return event.waypoint;
-          }
-          return e;
-        }).toList())),
-      );
+      if (current.page.getWaypointByName(event.name) == null) {
+        // Waypoint doesn't exist yet, create it instead
+        _saveState(
+          emit,
+          state: current.copyWith(
+              page: current.page.copyWith(
+                  waypoints: List<Waypoint>.from(current.page.waypoints)
+                    ..add(event.waypoint))),
+        );
+      } else {
+        _saveState(
+          emit,
+          state: current.copyWith(
+              page: current.page.copyWith(
+                  waypoints: current.page.waypoints.map((e) {
+            if (e.name == event.name) {
+              return event.waypoint;
+            }
+            return e;
+          }).toList())),
+        );
+      }
     });
     on<WaypointRemoved>((event, emit) {
       final current = state;

--- a/app/lib/views/main.dart
+++ b/app/lib/views/main.dart
@@ -249,6 +249,7 @@ class _ProjectPageState extends State<ProjectPage> {
       );
       setState(() {
         _transformCubit = TransformCubit();
+        _transformCubit?.teleportToWaypoint(page.getOriginWaypoint());
         _currentIndexCubit = CurrentIndexCubit(
           settingsCubit,
           _transformCubit!,

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -273,19 +273,17 @@ class _WaypointCreateDialogState extends State<WaypointCreateDialog> {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          ...!_replacing
-              ? [
-                  TextField(
-                    controller: _nameController,
-                    autofocus: true,
-                    decoration: InputDecoration(
-                      filled: true,
-                      labelText: LeapLocalizations.of(context).name,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                ]
-              : [],
+          if (!_replacing) ...[
+            TextField(
+              controller: _nameController,
+              autofocus: true,
+              decoration: InputDecoration(
+                filled: true,
+                labelText: LeapLocalizations.of(context).name,
+              ),
+            ),
+            const SizedBox(height: 10),
+          ],
           CheckboxListTile(
             title: Text(AppLocalizations.of(context).scale),
             value: _saveScale,

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -74,7 +74,7 @@ class WaypointsView extends StatelessWidget {
                                   showDialog<void>(
                                     builder: (context) => BlocProvider.value(
                                         value: bloc,
-                                        child: WaypointResetDialog(
+                                        child: WaypointClearOriginDialog(
                                           waypoint: origin,
                                         )),
                                     context: context,
@@ -345,15 +345,16 @@ class _WaypointReplaceDialogState extends State<WaypointReplaceDialog> {
   }
 }
 
-class WaypointResetDialog extends StatefulWidget {
+class WaypointClearOriginDialog extends StatefulWidget {
   final Waypoint waypoint;
-  const WaypointResetDialog({super.key, required this.waypoint});
+  const WaypointClearOriginDialog({super.key, required this.waypoint});
 
   @override
-  State<WaypointResetDialog> createState() => _WaypointResetDialogState();
+  State<WaypointClearOriginDialog> createState() =>
+      _WaypointClearOriginDialogState();
 }
 
-class _WaypointResetDialogState extends State<WaypointResetDialog> {
+class _WaypointClearOriginDialogState extends State<WaypointClearOriginDialog> {
   @override
   void dispose() {
     super.dispose();
@@ -374,17 +375,15 @@ class _WaypointResetDialogState extends State<WaypointResetDialog> {
         ),
         ElevatedButton(
           onPressed: () {
-            final newWaypoint =
-                Waypoint.defaultOrigin.copyWith(name: widget.waypoint.name);
             final bloc = context.read<DocumentBloc>();
             bloc.add(
-              WaypointChanged(widget.waypoint.name, newWaypoint),
+              WaypointRemoved(Waypoint.customOriginName),
             );
             Navigator.of(context).pop();
             final state = bloc.state;
             if (state is! DocumentLoadSuccess) return;
             state.currentIndexCubit.state.transformCubit
-                .teleportToWaypoint(newWaypoint);
+                .teleportToWaypoint(Waypoint.defaultOrigin);
           },
           child: Text(LeapLocalizations.of(context).reset),
         ),

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -22,7 +22,7 @@ class WaypointsView extends StatelessWidget {
               previous.page?.waypoints != current.page?.waypoints,
           builder: (context, state) {
             if (state is! DocumentLoadSuccess) return const SizedBox.shrink();
-            var waypoints = List.from(state.page.waypoints);
+            var waypoints = List<Waypoint>.from(state.page.waypoints);
             Waypoint origin = state.page.getOriginWaypoint();
             waypoints.removeWhere(
                 (waypoint) => waypoint.name == Waypoint.customOriginName);

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -368,6 +368,7 @@ class _WaypointClearOriginDialogState extends State<WaypointClearOriginDialog> {
             if (state is! DocumentLoadSuccess) return;
             state.currentIndexCubit.state.transformCubit
                 .teleportToWaypoint(Waypoint.defaultOrigin);
+            bloc.bake();
           },
           child: Text(LeapLocalizations.of(context).reset),
         ),

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -72,12 +72,62 @@ class WaypointsView extends StatelessWidget {
                             onPressed: () async {
                               final bloc = context.read<DocumentBloc>();
                               showDialog<void>(
-                                builder: (context) => BlocProvider.value(
-                                    value: bloc,
-                                    child: WaypointClearOriginDialog(
-                                      waypoint: origin,
-                                    )),
                                 context: context,
+                                builder: (builderContext) => BlocProvider.value(
+                                    value: bloc,
+                                    child: Builder(
+                                      builder: (builderContext) {
+                                        return AlertDialog(
+                                          title: Text(LeapLocalizations.of(
+                                                  builderContext)
+                                              .reset),
+                                          content: Column(
+                                            mainAxisSize: MainAxisSize.min,
+                                            children: [
+                                              Text(AppLocalizations.of(
+                                                      builderContext)
+                                                  .reallyReset)
+                                            ],
+                                          ),
+                                          actions: [
+                                            TextButton(
+                                              onPressed: () =>
+                                                  Navigator.of(builderContext)
+                                                      .pop(),
+                                              child: Text(
+                                                  MaterialLocalizations.of(
+                                                          builderContext)
+                                                      .cancelButtonLabel),
+                                            ),
+                                            ElevatedButton(
+                                              onPressed: () {
+                                                final bloc = builderContext
+                                                    .read<DocumentBloc>();
+                                                bloc.add(
+                                                  WaypointChanged(origin.name,
+                                                      Waypoint.defaultOrigin),
+                                                );
+                                                Navigator.of(builderContext)
+                                                    .pop();
+                                                final state = bloc.state;
+                                                if (state
+                                                    is! DocumentLoadSuccess) {
+                                                  return;
+                                                }
+                                                state.currentIndexCubit.state
+                                                    .transformCubit
+                                                    .teleportToWaypoint(
+                                                        Waypoint.defaultOrigin);
+                                                bloc.bake();
+                                              },
+                                              child: Text(LeapLocalizations.of(
+                                                      builderContext)
+                                                  .reset),
+                                            ),
+                                          ],
+                                        );
+                                      },
+                                    )),
                               );
                             },
                             child: Text(LeapLocalizations.of(context).reset),
@@ -273,54 +323,6 @@ class _WaypointCreateDialogState extends State<WaypointCreateDialog> {
             Navigator.of(context).pop();
           },
           child: Text(LeapLocalizations.of(context).create),
-        ),
-      ],
-    );
-  }
-}
-
-class WaypointClearOriginDialog extends StatefulWidget {
-  final Waypoint waypoint;
-  const WaypointClearOriginDialog({super.key, required this.waypoint});
-
-  @override
-  State<WaypointClearOriginDialog> createState() =>
-      _WaypointClearOriginDialogState();
-}
-
-class _WaypointClearOriginDialogState extends State<WaypointClearOriginDialog> {
-  @override
-  void dispose() {
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      title: Text(LeapLocalizations.of(context).reset),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [Text(AppLocalizations.of(context).reallyReset)],
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
-        ),
-        ElevatedButton(
-          onPressed: () {
-            final bloc = context.read<DocumentBloc>();
-            bloc.add(
-              WaypointChanged(widget.waypoint.name, Waypoint.defaultOrigin),
-            );
-            Navigator.of(context).pop();
-            final state = bloc.state;
-            if (state is! DocumentLoadSuccess) return;
-            state.currentIndexCubit.state.transformCubit
-                .teleportToWaypoint(Waypoint.defaultOrigin);
-            bloc.bake();
-          },
-          child: Text(LeapLocalizations.of(context).reset),
         ),
       ],
     );

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -64,6 +64,26 @@ class WaypointsView extends StatelessWidget {
                           },
                           child: Text(AppLocalizations.of(context).replace),
                         ),
+                        origin != Waypoint.defaultOrigin
+                            ? MenuItemButton(
+                                leadingIcon: const PhosphorIcon(
+                                  PhosphorIconsLight.clockClockwise,
+                                ),
+                                onPressed: () async {
+                                  final bloc = context.read<DocumentBloc>();
+                                  showDialog<void>(
+                                    builder: (context) => BlocProvider.value(
+                                        value: bloc,
+                                        child: WaypointResetDialog(
+                                          waypoint: origin,
+                                        )),
+                                    context: context,
+                                  );
+                                },
+                                child:
+                                    Text(LeapLocalizations.of(context).reset),
+                              )
+                            : Container(),
                       ],
                     ),
                     const Divider(),
@@ -319,6 +339,54 @@ class _WaypointReplaceDialogState extends State<WaypointReplaceDialog> {
             Navigator.of(context).pop();
           },
           child: Text(AppLocalizations.of(context).replace),
+        ),
+      ],
+    );
+  }
+}
+
+class WaypointResetDialog extends StatefulWidget {
+  final Waypoint waypoint;
+  const WaypointResetDialog({super.key, required this.waypoint});
+
+  @override
+  State<WaypointResetDialog> createState() => _WaypointResetDialogState();
+}
+
+class _WaypointResetDialogState extends State<WaypointResetDialog> {
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(LeapLocalizations.of(context).reset),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [Text(AppLocalizations.of(context).reallyReset)],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            final newWaypoint =
+                Waypoint.defaultOrigin.copyWith(name: widget.waypoint.name);
+            final bloc = context.read<DocumentBloc>();
+            bloc.add(
+              WaypointChanged(widget.waypoint.name, newWaypoint),
+            );
+            Navigator.of(context).pop();
+            final state = bloc.state;
+            if (state is! DocumentLoadSuccess) return;
+            state.currentIndexCubit.state.transformCubit
+                .teleportToWaypoint(newWaypoint);
+          },
+          child: Text(LeapLocalizations.of(context).reset),
         ),
       ],
     );

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -77,13 +77,9 @@ class WaypointsView extends StatelessWidget {
                                         title: Text(
                                             LeapLocalizations.of(context)
                                                 .reset),
-                                        content: Column(
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: [
-                                            Text(AppLocalizations.of(context)
-                                                .reallyReset)
-                                          ],
-                                        ),
+                                        content: Text(
+                                            AppLocalizations.of(context)
+                                                .reallyReset),
                                         actions: [
                                           TextButton(
                                             onPressed: () =>

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -72,6 +72,23 @@ class WaypointsView extends StatelessWidget {
                           actions: [
                             MenuItemButton(
                               leadingIcon: const PhosphorIcon(
+                                PhosphorIconsLight.mapPin,
+                              ),
+                              onPressed: () async {
+                                final bloc = context.read<DocumentBloc>();
+                                showDialog<void>(
+                                  builder: (context) => BlocProvider.value(
+                                      value: bloc,
+                                      child: WaypointReplaceDialog(
+                                        waypoint: waypoint,
+                                      )),
+                                  context: context,
+                                );
+                              },
+                              child: Text(AppLocalizations.of(context).replace),
+                            ),
+                            MenuItemButton(
+                              leadingIcon: const PhosphorIcon(
                                 PhosphorIconsLight.trash,
                               ),
                               onPressed: () async {
@@ -192,6 +209,73 @@ class _WaypointCreateDialogState extends State<WaypointCreateDialog> {
             Navigator.of(context).pop();
           },
           child: Text(LeapLocalizations.of(context).create),
+        ),
+      ],
+    );
+  }
+}
+
+class WaypointReplaceDialog extends StatefulWidget {
+  final Waypoint waypoint;
+  const WaypointReplaceDialog({super.key, required this.waypoint});
+
+  @override
+  State<WaypointReplaceDialog> createState() => _WaypointReplaceDialogState();
+}
+
+class _WaypointReplaceDialogState extends State<WaypointReplaceDialog> {
+  bool _saveScale = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _saveScale = widget.waypoint.scale != null;
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(AppLocalizations.of(context).replace),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CheckboxListTile(
+            title: Text(AppLocalizations.of(context).scale),
+            value: _saveScale,
+            controlAffinity: ListTileControlAffinity.leading,
+            onChanged: (value) =>
+                setState(() => _saveScale = value ?? _saveScale),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            final bloc = context.read<DocumentBloc>();
+            final state = bloc.state;
+            if (state is! DocumentLoadSuccess) return;
+            final transform =
+                state.currentIndexCubit.state.transformCubit.state;
+            final Waypoint newWaypoint = widget.waypoint.copyWith(
+              position: transform.position.toPoint(),
+              scale: _saveScale ? transform.size : null,
+            );
+
+            bloc.add(
+              WaypointChanged(widget.waypoint.name, newWaypoint),
+            );
+            Navigator.of(context).pop();
+          },
+          child: Text(AppLocalizations.of(context).replace),
         ),
       ],
     );

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -72,63 +72,51 @@ class WaypointsView extends StatelessWidget {
                             onPressed: () async {
                               final bloc = context.read<DocumentBloc>();
                               showDialog<void>(
-                                context: context,
-                                builder: (builderContext) => BlocProvider.value(
-                                    value: bloc,
-                                    child: Builder(
-                                      builder: (builderContext) {
-                                        return AlertDialog(
-                                          title: Text(LeapLocalizations.of(
-                                                  builderContext)
-                                              .reset),
-                                          content: Column(
-                                            mainAxisSize: MainAxisSize.min,
-                                            children: [
-                                              Text(AppLocalizations.of(
-                                                      builderContext)
-                                                  .reallyReset)
-                                            ],
-                                          ),
-                                          actions: [
-                                            TextButton(
-                                              onPressed: () =>
-                                                  Navigator.of(builderContext)
-                                                      .pop(),
-                                              child: Text(
-                                                  MaterialLocalizations.of(
-                                                          builderContext)
-                                                      .cancelButtonLabel),
-                                            ),
-                                            ElevatedButton(
-                                              onPressed: () {
-                                                final bloc = builderContext
-                                                    .read<DocumentBloc>();
-                                                bloc.add(
-                                                  WaypointChanged(origin.name,
-                                                      Waypoint.defaultOrigin),
-                                                );
-                                                Navigator.of(builderContext)
-                                                    .pop();
-                                                final state = bloc.state;
-                                                if (state
-                                                    is! DocumentLoadSuccess) {
-                                                  return;
-                                                }
-                                                state.currentIndexCubit.state
-                                                    .transformCubit
-                                                    .teleportToWaypoint(
-                                                        Waypoint.defaultOrigin);
-                                                bloc.bake();
-                                              },
-                                              child: Text(LeapLocalizations.of(
-                                                      builderContext)
-                                                  .reset),
-                                            ),
+                                  context: context,
+                                  builder: (context) => AlertDialog(
+                                        title: Text(
+                                            LeapLocalizations.of(context)
+                                                .reset),
+                                        content: Column(
+                                          mainAxisSize: MainAxisSize.min,
+                                          children: [
+                                            Text(AppLocalizations.of(context)
+                                                .reallyReset)
                                           ],
-                                        );
-                                      },
-                                    )),
-                              );
+                                        ),
+                                        actions: [
+                                          TextButton(
+                                            onPressed: () =>
+                                                Navigator.of(context).pop(),
+                                            child: Text(
+                                                MaterialLocalizations.of(
+                                                        context)
+                                                    .cancelButtonLabel),
+                                          ),
+                                          ElevatedButton(
+                                            onPressed: () {
+                                              bloc.add(
+                                                WaypointChanged(origin.name,
+                                                    Waypoint.defaultOrigin),
+                                              );
+                                              Navigator.of(context).pop();
+                                              final state = bloc.state;
+                                              if (state
+                                                  is! DocumentLoadSuccess) {
+                                                return;
+                                              }
+                                              state.currentIndexCubit.state
+                                                  .transformCubit
+                                                  .teleportToWaypoint(
+                                                      Waypoint.defaultOrigin);
+                                              bloc.bake();
+                                            },
+                                            child: Text(
+                                                LeapLocalizations.of(context)
+                                                    .reset),
+                                          ),
+                                        ],
+                                      ));
                             },
                             child: Text(LeapLocalizations.of(context).reset),
                           ),

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -22,18 +22,9 @@ class WaypointsView extends StatelessWidget {
               previous.page?.waypoints != current.page?.waypoints,
           builder: (context, state) {
             if (state is! DocumentLoadSuccess) return const SizedBox.shrink();
-            var waypoints = state.page.waypoints;
-            Waypoint origin;
-            int customOriginIndex = waypoints.indexWhere(
-                (waypoint) => waypoint.name == Waypoint.customOriginName);
-            bool hasCustomOrigin = customOriginIndex != -1;
-            if (hasCustomOrigin) {
-              origin = waypoints[customOriginIndex];
-              waypoints = List.from(waypoints);
-              waypoints.remove(origin);
-            } else {
-              origin = Waypoint.defaultOrigin;
-            }
+            var waypoints = List.from(state.page.waypoints);
+            Waypoint origin = state.page.getOriginWaypoint();
+            waypoints.removeWhere((waypoint) => waypoint.name == Waypoint.customOriginName);
             return Stack(
               children: [
                 ListView(

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -64,26 +64,24 @@ class WaypointsView extends StatelessWidget {
                           },
                           child: Text(AppLocalizations.of(context).replace),
                         ),
-                        origin != Waypoint.defaultOrigin
-                            ? MenuItemButton(
-                                leadingIcon: const PhosphorIcon(
-                                  PhosphorIconsLight.clockClockwise,
-                                ),
-                                onPressed: () async {
-                                  final bloc = context.read<DocumentBloc>();
-                                  showDialog<void>(
-                                    builder: (context) => BlocProvider.value(
-                                        value: bloc,
-                                        child: WaypointClearOriginDialog(
-                                          waypoint: origin,
-                                        )),
-                                    context: context,
-                                  );
-                                },
-                                child:
-                                    Text(LeapLocalizations.of(context).reset),
-                              )
-                            : Container(),
+                        if (origin != Waypoint.defaultOrigin)
+                          MenuItemButton(
+                            leadingIcon: const PhosphorIcon(
+                              PhosphorIconsLight.clockClockwise,
+                            ),
+                            onPressed: () async {
+                              final bloc = context.read<DocumentBloc>();
+                              showDialog<void>(
+                                builder: (context) => BlocProvider.value(
+                                    value: bloc,
+                                    child: WaypointClearOriginDialog(
+                                      waypoint: origin,
+                                    )),
+                                context: context,
+                              );
+                            },
+                            child: Text(LeapLocalizations.of(context).reset),
+                          ),
                       ],
                     ),
                     const Divider(),

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -24,7 +24,8 @@ class WaypointsView extends StatelessWidget {
             if (state is! DocumentLoadSuccess) return const SizedBox.shrink();
             var waypoints = List.from(state.page.waypoints);
             Waypoint origin = state.page.getOriginWaypoint();
-            waypoints.removeWhere((waypoint) => waypoint.name == Waypoint.customOriginName);
+            waypoints.removeWhere(
+                (waypoint) => waypoint.name == Waypoint.customOriginName);
             return Stack(
               children: [
                 ListView(

--- a/app/lib/views/navigator/waypoints.dart
+++ b/app/lib/views/navigator/waypoints.dart
@@ -25,7 +25,7 @@ class WaypointsView extends StatelessWidget {
             var waypoints = List<Waypoint>.from(state.page.waypoints);
             Waypoint origin = state.page.getOriginWaypoint();
             waypoints.removeWhere(
-                (waypoint) => waypoint.name == Waypoint.customOriginName);
+                (waypoint) => waypoint.name == Waypoint.originName);
             return Stack(
               children: [
                 ListView(
@@ -99,7 +99,7 @@ class WaypointsView extends StatelessWidget {
                       itemBuilder: (BuildContext context, int index) {
                         final waypoint = waypoints[index];
                         return EditableListTile(
-                          key: ValueKey(waypoint.name),
+                          key: ValueKey(waypoint.name ?? ''),
                           initialValue: waypoint.name,
                           onTap: () {
                             context.read<TransformCubit>().teleportToWaypoint(
@@ -316,23 +316,9 @@ class _WaypointReplaceDialogState extends State<WaypointReplaceDialog> {
               scale: _saveScale ? transform.size : null,
             );
 
-            if (widget.waypoint == Waypoint.defaultOrigin &&
-                widget.waypoint.name != Waypoint.customOriginName) {
-              // Setting custom origin waypoint for the first time
-              bloc.add(
-                WaypointCreated(
-                  Waypoint(
-                    Waypoint.customOriginName,
-                    newWaypoint.position,
-                    newWaypoint.scale,
-                  ),
-                ),
-              );
-            } else {
-              bloc.add(
-                WaypointChanged(widget.waypoint.name, newWaypoint),
-              );
-            }
+            bloc.add(
+              WaypointChanged(widget.waypoint.name, newWaypoint),
+            );
 
             Navigator.of(context).pop();
           },
@@ -375,7 +361,7 @@ class _WaypointClearOriginDialogState extends State<WaypointClearOriginDialog> {
           onPressed: () {
             final bloc = context.read<DocumentBloc>();
             bloc.add(
-              WaypointRemoved(Waypoint.customOriginName),
+              WaypointChanged(widget.waypoint.name, Waypoint.defaultOrigin),
             );
             Navigator.of(context).pop();
             final state = bloc.state;

--- a/app/lib/widgets/search.dart
+++ b/app/lib/widgets/search.dart
@@ -53,7 +53,7 @@ class SearchButton extends StatelessWidget {
         PageResult e => e.name,
         ElementResult e => e.text,
         AreaResult e => e.area.name,
-        WaypointResult e => e.waypoint.name,
+        WaypointResult e => e.waypoint.name ?? '',
         ToolResult e => e.tool.getDisplay(context),
       };
 


### PR DESCRIPTION
This change adds a few features to the waypoint system which allow users to adjust waypoints without re-creating them, including the Origin waypoint.

# Justification
As a note grows and you move elements around to reorganize your work, waypoints that you have defined may no longer have relevant positions or scales. If the center point of the elements related to a waypoint naturally starts to drift away from the waypoint's position, you may want to re-define the position of the waypoint. If the group of elements grows significantly, you may want to re-define the scale of a waypoint.

This also applies to the Origin waypoint as well. As your note grows and the most important parts of your note are no longer at position `(0,0)`, the Origin waypoint starts to become less and less relevant to the user. And because notes always load at position `(0,0)` with 100% scale, the first thing you see after the note loads may be a very small and unimportant part of your note, and you may need to reposition / re-scale your note after every load.

# Changes
## Ability to re-define user-created waypoints
Adds a new option in the waypoint item menu to "Replace" a waypoint, which overwrites the waypoint with the current position and (optionally) scale.

(I feel like the Replace dialog is a little bare and could use some helpful text, but I couldn't think of something good enough.)

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/923f3a99-a9d4-4dde-989f-d825506b4c66)

![image](https://github.com/user-attachments/assets/f245799a-2a47-4bcf-bd20-7c35cd29c500)

</details>

## Ability to re-define and reset the Origin waypoint
Adds an option to replace the Origin waypoint. After this waypoint has been replaced, a new option will be added called "Reset", which resets the waypoint's transform back to the default.

ℹ️ This uses a hidden waypoint called `_origin` under the hood. When a waypoint called `_origin` exists, the Origin waypoint button takes it as its associated waypoint, otherwise it falls-back to the static default origin. The Replace button creates (or replaces) this waypoint, and the Reset button deletes it.

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/2cf267f3-ae75-4a1c-a791-50db5dbcaba2)

![image](https://github.com/user-attachments/assets/622fbcfe-fff0-40eb-ae0b-81f6e591254d)

![image](https://github.com/user-attachments/assets/7d7817fb-3eb0-4613-b838-4aaec49a99cc)

</details>

## Teleport to Origin on note load

When a new note is loaded, teleport to the Origin waypoint. If a custom Origin waypoint has been defined, use that, otherwise use the default Origin waypoint.

ℹ️ This does _not_ apply when switching pages, because I believe the page system is currently designed to keep the same transform when switching between pages, which seems like a helpful feature in certain cases. However, if this is not intended, I can make it so that switching to a page teleports to that page's origin.