### PR TITLE
Fix reversed area transition icons in context menu

### DIFF
--- a/app/lib/dialogs/area/context.dart
+++ b/app/lib/dialogs/area/context.dart
@@ -45,8 +45,8 @@ ContextMenuBuilder buildAreaContextMenu(
         ),
         ContextMenuItem(
           icon: area.name == state.currentAreaName
-              ? const PhosphorIcon(PhosphorIconsLight.signIn)
-              : const PhosphorIcon(PhosphorIconsLight.signOut),
+              ? const PhosphorIcon(PhosphorIconsLight.signOut)
+              : const PhosphorIcon(PhosphorIconsLight.signIn),
           label: area.name == state.currentAreaName
               ? AppLocalizations.of(context).exitArea
               : AppLocalizations.of(context).enterArea,

--- a/app/lib/views/app_bar.dart
+++ b/app/lib/views/app_bar.dart
@@ -359,8 +359,8 @@ class _AppBarTitleState extends State<_AppBarTitle> {
               ),
             if (state.currentAreaName.isNotEmpty)
               IconButton(
-                icon: const PhosphorIcon(PhosphorIconsLight.door),
-                tooltip: AppLocalizations.of(context).exit,
+                icon: const PhosphorIcon(PhosphorIconsLight.signOut),
+                tooltip: AppLocalizations.of(context).exitArea,
                 onPressed: () {
                   context
                       .read<DocumentBloc>()


### PR DESCRIPTION
Previously, the area context menu was showing the exit icon for entering and vice versa. Now, the icons match the behavior in the area navigator.

### Old:
![image](https://github.com/user-attachments/assets/96ecbc25-5776-48cc-874d-1a3636ca934d)
![image](https://github.com/user-attachments/assets/a1a07e47-96e4-4761-b38f-31f3ce0d6b0a)

### New:
![image](https://github.com/user-attachments/assets/dbe206ab-d28d-4d27-bc99-8df0a7cc6ec9)
![image](https://github.com/user-attachments/assets/c45dd129-2147-46f4-a52d-e7c65a626eb1)
