### PR TITLE
Fix performance drop after using path eraser or deleting elements

### DIFF
--- a/app/lib/bloc/document_bloc.dart
+++ b/app/lib/bloc/document_bloc.dart
@@ -350,6 +350,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
         state: current.copyWith(page: newPage, data: data),
         reset: true,
       );
+      // bake();
     }, transformer: sequential());
     on<DocumentDescriptionChanged>((event, emit) {
       final current = state;
@@ -1073,6 +1074,11 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
       {Size? viewportSize, double? pixelRatio, bool reset = false}) async {
     final current = state;
     if (current is! DocumentLoaded) return;
+    print('>>>>> PASSED SIZE: $viewportSize');
+    if (viewportSize == null && current is DocumentLoadSuccess) {
+      viewportSize = current.cameraViewport.toRealSize();
+      print('>>>>> ACTUAL VIEWPORT SIZE: ${viewportSize}');
+    }
     return current.bake(
         viewportSize: viewportSize, pixelRatio: pixelRatio, reset: reset);
   }

--- a/app/lib/bloc/document_bloc.dart
+++ b/app/lib/bloc/document_bloc.dart
@@ -325,7 +325,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
         unbake: true,
       );
     });
-    on<ElementsRemoved>((event, emit) {
+    on<ElementsRemoved>((event, emit) async {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
       if (!(current.embedding?.editable ?? true)) return;
@@ -350,7 +350,9 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
         state: current.copyWith(page: newPage, data: data),
         reset: true,
       );
-      // bake();
+      Future.delayed(const Duration(milliseconds: 100), () {
+        bake();
+      });
     }, transformer: sequential());
     on<DocumentDescriptionChanged>((event, emit) {
       final current = state;
@@ -1074,10 +1076,8 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
       {Size? viewportSize, double? pixelRatio, bool reset = false}) async {
     final current = state;
     if (current is! DocumentLoaded) return;
-    print('>>>>> PASSED SIZE: $viewportSize');
     if (viewportSize == null && current is DocumentLoadSuccess) {
       viewportSize = current.cameraViewport.toRealSize();
-      print('>>>>> ACTUAL VIEWPORT SIZE: ${viewportSize}');
     }
     return current.bake(
         viewportSize: viewportSize, pixelRatio: pixelRatio, reset: reset);

--- a/app/lib/bloc/document_bloc.dart
+++ b/app/lib/bloc/document_bloc.dart
@@ -325,7 +325,7 @@ class DocumentBloc extends ReplayBloc<DocumentEvent, DocumentState> {
         unbake: true,
       );
     });
-    on<ElementsRemoved>((event, emit) async {
+    on<ElementsRemoved>((event, emit) {
       final current = state;
       if (current is! DocumentLoadSuccess) return;
       if (!(current.embedding?.editable ?? true)) return;

--- a/app/lib/cubits/current_index.dart
+++ b/app/lib/cubits/current_index.dart
@@ -1179,17 +1179,12 @@ class CurrentIndexCubit extends Cubit<CurrentIndex> {
     } else if (backgrounds != null) {
       this.unbake(backgrounds: backgrounds);
     } else {
-      print('>>>>> UNBAKED ELEMENTS: ${elements.length}');
       withUnbaked(elements);
     }
 
     setSaveState(saved: SaveState.unsaved);
     if (current.embedding != null) {
       return;
-    }
-    AssetLocation? path = current.location;
-    if (current.hasAutosave()) {
-      path = await current.save(path);
     }
     if (reset) {
       loadElements(current);
@@ -1199,6 +1194,10 @@ class CurrentIndexCubit extends Cubit<CurrentIndex> {
     }
     if (updateIndex) {
       this.updateIndex(bloc);
+    }
+    AssetLocation? path = current.location;
+    if (current.hasAutosave()) {
+      path = await current.save(path);
     }
   }
 

--- a/app/lib/cubits/current_index.dart
+++ b/app/lib/cubits/current_index.dart
@@ -1179,6 +1179,7 @@ class CurrentIndexCubit extends Cubit<CurrentIndex> {
     } else if (backgrounds != null) {
       this.unbake(backgrounds: backgrounds);
     } else {
+      print('>>>>> UNBAKED ELEMENTS: ${elements.length}');
       withUnbaked(elements);
     }
 

--- a/app/lib/handlers/path_eraser.dart
+++ b/app/lib/handlers/path_eraser.dart
@@ -71,8 +71,6 @@ class PathEraserHandler extends Handler<PathEraserTool> {
   void onPointerUp(PointerUpEvent event, EventContext context) {
     if (_erased.isNotEmpty) {
       context.getDocumentBloc().add(ElementsRemoved(_erased.toList()));
-      // await Future.delayed(Duration(milliseconds: 5000));
-      // context.bake(reset: true);
     }
   }
 

--- a/app/lib/handlers/path_eraser.dart
+++ b/app/lib/handlers/path_eraser.dart
@@ -71,6 +71,8 @@ class PathEraserHandler extends Handler<PathEraserTool> {
   void onPointerUp(PointerUpEvent event, EventContext context) {
     if (_erased.isNotEmpty) {
       context.getDocumentBloc().add(ElementsRemoved(_erased.toList()));
+      // await Future.delayed(Duration(milliseconds: 5000));
+      // context.bake(reset: true);
     }
   }
 

--- a/app/lib/models/viewport.dart
+++ b/app/lib/models/viewport.dart
@@ -20,16 +20,16 @@ class CameraViewport extends Equatable {
   final double x, y;
   final RenderResolution resolution;
 
-  const CameraViewport.unbaked(
-      [this.backgrounds = const [],
-      this.unbakedElements = const [],
-      List<Renderer<PadElement>>? visibleElements])
-      : image = null,
+  const CameraViewport.unbaked([
+    this.backgrounds = const [],
+    this.unbakedElements = const [],
+    List<Renderer<PadElement>>? visibleElements,
+    this.width,
+    this.height,
+  ])  : image = null,
         belowLayerImage = null,
         aboveLayerImage = null,
         scale = 1,
-        width = null,
-        height = null,
         bakedElements = const [],
         pixelRatio = 1,
         x = 0,
@@ -108,14 +108,17 @@ class CameraViewport extends Equatable {
     List<Renderer<PadElement>>? visibleElements,
   }) =>
       CameraViewport.unbaked(
-          backgrounds ?? this.backgrounds,
-          unbakedElements ??
-              (List<Renderer<PadElement>>.from(this.unbakedElements)
-                ..addAll(bakedElements)),
-          visibleElements ??
-              unbakedElements ??
-              (List<Renderer<PadElement>>.from(this.unbakedElements)
-                ..addAll(bakedElements)));
+        backgrounds ?? this.backgrounds,
+        unbakedElements ??
+            (List<Renderer<PadElement>>.from(this.unbakedElements)
+              ..addAll(bakedElements)),
+        visibleElements ??
+            unbakedElements ??
+            (List<Renderer<PadElement>>.from(this.unbakedElements)
+              ..addAll(bakedElements)),
+        width,
+        height,
+      );
 
   CameraViewport bake({
     required ui.Image image,


### PR DESCRIPTION
This issue was caused by two things:
1. All elements are unbaked during the `ElementsRemoved` event, but previously, no bake would be triggered afterwards, so the next action would be operating on a completely un-baked canvas.
2. `CameraViewport` height and width were getting nulled-out during the unbake, so if an event happened later that would trigger a bake (like writing with the pen tool), [the bake would abort due to viewport object having no size](https://github.com/LinwoodDev/Butterfly/blob/9390ab5214d04a7723fe82a00f4679a397603558/app/lib/cubits/current_index.dart#L657). This is the reason that using the hand tool fixed the lag, because movement gestures update the viewport size, which allowed future bakes to complete normally.

⚠️ As part of this, I made a change in `app/lib/cubits/current_index.dart` that I don't _think_ is problematic, but figured I should mention it: I changed the order of actions in `CurrentIndexCubit.stateChanged`, so the auto-save happens at the _end_, after loads and refreshes, which helped reduce lag before the bakes. I couldn't find any issues with this in my testing, but there might be some side-effects that I didn't think of.

Partially solves #827. This fixes actions that use `ElementsRemoved`, but other actions such as undo and non-path eraser have not been solved in this PR. (I'd be happy to investigate those, but I probably won't have time in the near future.)