### PR TITLE
Fix issue with editing text in the navigation rail on tablet

### DIFF
--- a/app/lib/views/main.dart
+++ b/app/lib/views/main.dart
@@ -579,6 +579,7 @@ class _MainBody extends StatelessWidget {
               final optPos = settings.optionsPanelPosition;
               return LayoutBuilder(
                 builder: (context, constraints) {
+                  // Use PlatformDispatcher as a workaround for MediaQuery.viewInsets not updating fast enough. See: https://stackoverflow.com/a/64473806
                   final Iterable<FlutterView> windowViews =
                       PlatformDispatcher.instance.views;
                   final double bottomInset = windowViews.isEmpty

--- a/app/lib/views/main.dart
+++ b/app/lib/views/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:butterfly/api/close.dart';
 import 'package:butterfly/api/file_system.dart';
@@ -578,11 +579,17 @@ class _MainBody extends StatelessWidget {
               final optPos = settings.optionsPanelPosition;
               return LayoutBuilder(
                 builder: (context, constraints) {
-                  final isMobile =
+                  final Iterable<FlutterView> windowViews =
+                      PlatformDispatcher.instance.views;
+                  final double bottomInset = windowViews.isEmpty
+                      ? 0
+                      : windowViews.first.viewInsets.bottom /
+                          windowViews.first.devicePixelRatio;
+                  final bool isMobile =
                       constraints.maxWidth < LeapBreakpoints.compact;
-                  final isLarge =
+                  final bool isLarge =
                       constraints.maxWidth >= LeapBreakpoints.expanded &&
-                          constraints.maxHeight >= 400;
+                          (constraints.maxHeight + bottomInset) >= 400;
                   final toolbar = EditToolbar(
                     isMobile: isMobile,
                     centered: true,

--- a/app/lib/views/navigator/view.dart
+++ b/app/lib/views/navigator/view.dart
@@ -131,28 +131,41 @@ class _NavigatorViewState extends State<NavigatorView>
                       return child!;
                     }),
               ),
-              NavigationRail(
-                minWidth: kNavigationRailWidth,
-                destinations: NavigatorPage.values
-                    .map(
-                      (e) => NavigationRailDestination(
-                        icon: PhosphorIcon(e.icon(PhosphorIconsStyle.light)),
-                        label: Text(e.getLocalizedName(context)),
+              LayoutBuilder(
+                builder: (context, constraint) => SingleChildScrollView(
+                  child: ConstrainedBox(
+                    constraints:
+                        BoxConstraints(minHeight: constraint.maxHeight),
+                    child: IntrinsicHeight(
+                      child: NavigationRail(
+                        minWidth: kNavigationRailWidth,
+                        destinations: NavigatorPage.values
+                            .map(
+                              (e) => NavigationRailDestination(
+                                icon: PhosphorIcon(
+                                    e.icon(PhosphorIconsStyle.light)),
+                                label: Text(e.getLocalizedName(context)),
+                              ),
+                            )
+                            .toList(),
+                        labelType: NavigationRailLabelType.none,
+                        selectedIndex:
+                            currentIndex.navigatorEnabled ? selected : null,
+                        groupAlignment: 0,
+                        onDestinationSelected: (index) {
+                          final cubit = context.read<CurrentIndexCubit>();
+                          if (selected == index) {
+                            cubit.setNavigatorEnabled(
+                                !currentIndex.navigatorEnabled);
+                            return;
+                          }
+                          cubit.setNavigatorPage(NavigatorPage.values[index]);
+                          cubit.setNavigatorEnabled(true);
+                        },
                       ),
-                    )
-                    .toList(),
-                labelType: NavigationRailLabelType.none,
-                selectedIndex: currentIndex.navigatorEnabled ? selected : null,
-                groupAlignment: 0,
-                onDestinationSelected: (index) {
-                  final cubit = context.read<CurrentIndexCubit>();
-                  if (selected == index) {
-                    cubit.setNavigatorEnabled(!currentIndex.navigatorEnabled);
-                    return;
-                  }
-                  cubit.setNavigatorPage(NavigatorPage.values[index]);
-                  cubit.setNavigatorEnabled(true);
-                },
+                    ),
+                  ),
+                ),
               ),
             ],
           );


### PR DESCRIPTION
Fixes an issue where pages, layers, waypoints, and files could not be renamed from the navigation rail on tablet because the on-screen keyboard would immediately disappear.

The app's scaffold follows the default behavior of resizing when an on-screen keyboard appears (which is good), but this caused the height of the app to no longer meet the minimum height required to display the navigation rail when the keyboard was displayed on certain tablets. This change queries the current bottom view inset and adds it to the app's height during the navigation rail height check, effectively making the keyboard being on-screen have no effect on the navigation rail check.

Closes #834 