### PR TITLE
Fix crash during canvas movement

### DIFF
--- a/app/lib/cubits/current_index.dart
+++ b/app/lib/cubits/current_index.dart
@@ -646,13 +646,25 @@ class CurrentIndexCubit extends Cubit<CurrentIndex> {
       renderers.firstWhereOrNull((renderer) => renderer.element == element);
 
   bool _isBaking = false;
+  Function? _queuedBake;
   Future<void> bake(DocumentLoaded blocState,
       {Size? viewportSize,
       double? pixelRatio,
       bool reset = false,
       bool resetAllLayers = false}) async {
-    if (_isBaking) return;
-    _isBaking = true;
+    if (_isBaking) {
+      _queuedBake = () {
+        bake(
+          blocState,
+          viewportSize: viewportSize,
+          pixelRatio: pixelRatio,
+          reset: reset,
+          resetAllLayers: resetAllLayers,
+        );
+      };
+      return;
+    }
+    _queuedBake = null;
     var cameraViewport = state.cameraViewport;
     final resolution = state.settingsCubit.state.renderResolution;
     var size = viewportSize ?? cameraViewport.toSize();
@@ -714,6 +726,8 @@ class CurrentIndexCubit extends Cubit<CurrentIndex> {
         ..addAll(renderers);
     }
     canvas.scale(ratio);
+
+    _isBaking = true;
 
     // Wait one frame
     await Future.delayed(const Duration(milliseconds: 1));
@@ -827,6 +841,9 @@ class CurrentIndexCubit extends Cubit<CurrentIndex> {
             belowLayerImage: belowLayerImage,
             aboveLayerImage: aboveLayerImage)));
     _isBaking = false;
+    if (_queuedBake != null) {
+      _queuedBake?.call();
+    }
   }
 
   Future<ByteData?> render(NoteData document, DocumentPage page,

--- a/app/lib/cubits/current_index.dart
+++ b/app/lib/cubits/current_index.dart
@@ -645,11 +645,14 @@ class CurrentIndexCubit extends Cubit<CurrentIndex> {
   Renderer? getRenderer(PadElement element) =>
       renderers.firstWhereOrNull((renderer) => renderer.element == element);
 
+  bool _isBaking = false;
   Future<void> bake(DocumentLoaded blocState,
       {Size? viewportSize,
       double? pixelRatio,
       bool reset = false,
       bool resetAllLayers = false}) async {
+    if (_isBaking) return;
+    _isBaking = true;
     var cameraViewport = state.cameraViewport;
     final resolution = state.settingsCubit.state.renderResolution;
     var size = viewportSize ?? cameraViewport.toSize();
@@ -823,6 +826,7 @@ class CurrentIndexCubit extends Cubit<CurrentIndex> {
             visibleElements: visibleElements,
             belowLayerImage: belowLayerImage,
             aboveLayerImage: aboveLayerImage)));
+    _isBaking = false;
   }
 
   Future<ByteData?> render(NoteData document, DocumentPage page,


### PR DESCRIPTION
Prevents a crash when moving around the canvas, and some other situations where multiple bakes happened in quick succession.

This PR contains 2 commits, one of which might not be necessary...
- https://github.com/LinwoodDev/Butterfly/commit/2397732ebbe06af95d3ef3153b58b900db450b77 Prevents multiple concurrent bakes by checking if a bake is already in progress. This fixes the crash, but completely abandons the newer bake request, so if there was a new element, it will remain unbaked.
- https://github.com/LinwoodDev/Butterfly/commit/2b79c925c666cef40f8e2098da5e427cc199a9c6 When a bake is already in-progress, the new bake request will be queued and performed after the current bake is completed. Only one bake request will be queued, and if a bake is already queued, it will be replaced by the newer request. This fixes the issue mentioned above by ensuring that a bake is always performed sometime after a bake is requested.

I _think_ that queuing the bake request is a good idea, but I wasn't able to find any evidence that it causes a tangible performance improvement, and it does add some level of complexity. So if you think we should just keep it simple and go with the first commit, I'd be happy to reset this branch to https://github.com/LinwoodDev/Butterfly/commit/2397732ebbe06af95d3ef3153b58b900db450b77 for cleaner merging.

Closes #837 