### PR TITLE
Add input mapping for invertedStylus

### DIFF
--- a/app/lib/cubits/settings.dart
+++ b/app/lib/cubits/settings.dart
@@ -101,6 +101,7 @@ class InputMappingDefault {
       InputMapping(InputMapping.handToolValue);
   static const InputMapping rightMouse = InputMapping(1);
   static const InputMapping pen = InputMapping(InputMapping.activeToolValue);
+  static const InputMapping invertedPen = InputMapping(3);
   static const InputMapping firstPenButton = InputMapping(2);
   static const InputMapping secondPenButton = InputMapping(1);
   static const InputMapping touch = InputMapping(InputMapping.activeToolValue);
@@ -175,6 +176,7 @@ sealed class InputConfiguration with _$InputConfiguration {
     @Default(InputMappingDefault.middleMouse) InputMapping middleMouse,
     @Default(InputMappingDefault.rightMouse) InputMapping rightMouse,
     @Default(InputMappingDefault.pen) InputMapping pen,
+    @Default(InputMappingDefault.invertedPen) InputMapping invertedPen,
     @Default(InputMappingDefault.firstPenButton) InputMapping firstPenButton,
     @Default(InputMappingDefault.secondPenButton) InputMapping secondPenButton,
     @Default(InputMappingDefault.touch) InputMapping touch,
@@ -188,6 +190,7 @@ sealed class InputConfiguration with _$InputConfiguration {
         middleMouse,
         rightMouse,
         pen,
+        invertedPen,
         firstPenButton,
         secondPenButton,
         touch

--- a/app/lib/cubits/settings.freezed.dart
+++ b/app/lib/cubits/settings.freezed.dart
@@ -19,6 +19,7 @@ mixin _$InputConfiguration implements DiagnosticableTreeMixin {
   InputMapping get middleMouse;
   InputMapping get rightMouse;
   InputMapping get pen;
+  InputMapping get invertedPen;
   InputMapping get firstPenButton;
   InputMapping get secondPenButton;
   InputMapping get touch;
@@ -42,6 +43,7 @@ mixin _$InputConfiguration implements DiagnosticableTreeMixin {
       ..add(DiagnosticsProperty('middleMouse', middleMouse))
       ..add(DiagnosticsProperty('rightMouse', rightMouse))
       ..add(DiagnosticsProperty('pen', pen))
+      ..add(DiagnosticsProperty('invertedPen', invertedPen))
       ..add(DiagnosticsProperty('firstPenButton', firstPenButton))
       ..add(DiagnosticsProperty('secondPenButton', secondPenButton))
       ..add(DiagnosticsProperty('touch', touch));
@@ -59,6 +61,8 @@ mixin _$InputConfiguration implements DiagnosticableTreeMixin {
             (identical(other.rightMouse, rightMouse) ||
                 other.rightMouse == rightMouse) &&
             (identical(other.pen, pen) || other.pen == pen) &&
+            (identical(other.invertedPen, invertedPen) ||
+                other.invertedPen == invertedPen) &&
             (identical(other.firstPenButton, firstPenButton) ||
                 other.firstPenButton == firstPenButton) &&
             (identical(other.secondPenButton, secondPenButton) ||
@@ -69,11 +73,11 @@ mixin _$InputConfiguration implements DiagnosticableTreeMixin {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, leftMouse, middleMouse,
-      rightMouse, pen, firstPenButton, secondPenButton, touch);
+      rightMouse, pen, invertedPen, firstPenButton, secondPenButton, touch);
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'InputConfiguration(leftMouse: $leftMouse, middleMouse: $middleMouse, rightMouse: $rightMouse, pen: $pen, firstPenButton: $firstPenButton, secondPenButton: $secondPenButton, touch: $touch)';
+    return 'InputConfiguration(leftMouse: $leftMouse, middleMouse: $middleMouse, rightMouse: $rightMouse, pen: $pen, invertedPen: $invertedPen, firstPenButton: $firstPenButton, secondPenButton: $secondPenButton, touch: $touch)';
   }
 }
 
@@ -88,6 +92,7 @@ abstract mixin class $InputConfigurationCopyWith<$Res> {
       InputMapping middleMouse,
       InputMapping rightMouse,
       InputMapping pen,
+      InputMapping invertedPen,
       InputMapping firstPenButton,
       InputMapping secondPenButton,
       InputMapping touch});
@@ -110,6 +115,7 @@ class _$InputConfigurationCopyWithImpl<$Res>
     Object? middleMouse = null,
     Object? rightMouse = null,
     Object? pen = null,
+    Object? invertedPen = null,
     Object? firstPenButton = null,
     Object? secondPenButton = null,
     Object? touch = null,
@@ -130,6 +136,10 @@ class _$InputConfigurationCopyWithImpl<$Res>
       pen: null == pen
           ? _self.pen
           : pen // ignore: cast_nullable_to_non_nullable
+              as InputMapping,
+      invertedPen: null == invertedPen
+          ? _self.invertedPen
+          : invertedPen // ignore: cast_nullable_to_non_nullable
               as InputMapping,
       firstPenButton: null == firstPenButton
           ? _self.firstPenButton
@@ -156,6 +166,7 @@ class _InputConfiguration extends InputConfiguration
       this.middleMouse = InputMappingDefault.middleMouse,
       this.rightMouse = InputMappingDefault.rightMouse,
       this.pen = InputMappingDefault.pen,
+      this.invertedPen = InputMappingDefault.invertedPen,
       this.firstPenButton = InputMappingDefault.firstPenButton,
       this.secondPenButton = InputMappingDefault.secondPenButton,
       this.touch = InputMappingDefault.touch})
@@ -175,6 +186,9 @@ class _InputConfiguration extends InputConfiguration
   @override
   @JsonKey()
   final InputMapping pen;
+  @override
+  @JsonKey()
+  final InputMapping invertedPen;
   @override
   @JsonKey()
   final InputMapping firstPenButton;
@@ -208,6 +222,7 @@ class _InputConfiguration extends InputConfiguration
       ..add(DiagnosticsProperty('middleMouse', middleMouse))
       ..add(DiagnosticsProperty('rightMouse', rightMouse))
       ..add(DiagnosticsProperty('pen', pen))
+      ..add(DiagnosticsProperty('invertedPen', invertedPen))
       ..add(DiagnosticsProperty('firstPenButton', firstPenButton))
       ..add(DiagnosticsProperty('secondPenButton', secondPenButton))
       ..add(DiagnosticsProperty('touch', touch));
@@ -225,6 +240,8 @@ class _InputConfiguration extends InputConfiguration
             (identical(other.rightMouse, rightMouse) ||
                 other.rightMouse == rightMouse) &&
             (identical(other.pen, pen) || other.pen == pen) &&
+            (identical(other.invertedPen, invertedPen) ||
+                other.invertedPen == invertedPen) &&
             (identical(other.firstPenButton, firstPenButton) ||
                 other.firstPenButton == firstPenButton) &&
             (identical(other.secondPenButton, secondPenButton) ||
@@ -235,11 +252,11 @@ class _InputConfiguration extends InputConfiguration
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, leftMouse, middleMouse,
-      rightMouse, pen, firstPenButton, secondPenButton, touch);
+      rightMouse, pen, invertedPen, firstPenButton, secondPenButton, touch);
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'InputConfiguration(leftMouse: $leftMouse, middleMouse: $middleMouse, rightMouse: $rightMouse, pen: $pen, firstPenButton: $firstPenButton, secondPenButton: $secondPenButton, touch: $touch)';
+    return 'InputConfiguration(leftMouse: $leftMouse, middleMouse: $middleMouse, rightMouse: $rightMouse, pen: $pen, invertedPen: $invertedPen, firstPenButton: $firstPenButton, secondPenButton: $secondPenButton, touch: $touch)';
   }
 }
 
@@ -256,6 +273,7 @@ abstract mixin class _$InputConfigurationCopyWith<$Res>
       InputMapping middleMouse,
       InputMapping rightMouse,
       InputMapping pen,
+      InputMapping invertedPen,
       InputMapping firstPenButton,
       InputMapping secondPenButton,
       InputMapping touch});
@@ -278,6 +296,7 @@ class __$InputConfigurationCopyWithImpl<$Res>
     Object? middleMouse = null,
     Object? rightMouse = null,
     Object? pen = null,
+    Object? invertedPen = null,
     Object? firstPenButton = null,
     Object? secondPenButton = null,
     Object? touch = null,
@@ -298,6 +317,10 @@ class __$InputConfigurationCopyWithImpl<$Res>
       pen: null == pen
           ? _self.pen
           : pen // ignore: cast_nullable_to_non_nullable
+              as InputMapping,
+      invertedPen: null == invertedPen
+          ? _self.invertedPen
+          : invertedPen // ignore: cast_nullable_to_non_nullable
               as InputMapping,
       firstPenButton: null == firstPenButton
           ? _self.firstPenButton

--- a/app/lib/cubits/settings.g.dart
+++ b/app/lib/cubits/settings.g.dart
@@ -20,6 +20,9 @@ _InputConfiguration _$InputConfigurationFromJson(Map json) =>
       pen: json['pen'] == null
           ? InputMappingDefault.pen
           : InputMapping.fromJson((json['pen'] as num).toInt()),
+      invertedPen: json['invertedPen'] == null
+          ? InputMappingDefault.invertedPen
+          : InputMapping.fromJson((json['invertedPen'] as num).toInt()),
       firstPenButton: json['firstPenButton'] == null
           ? InputMappingDefault.firstPenButton
           : InputMapping.fromJson((json['firstPenButton'] as num).toInt()),
@@ -37,6 +40,7 @@ Map<String, dynamic> _$InputConfigurationToJson(_InputConfiguration instance) =>
       'middleMouse': instance.middleMouse.toJson(),
       'rightMouse': instance.rightMouse.toJson(),
       'pen': instance.pen.toJson(),
+      'invertedPen': instance.invertedPen.toJson(),
       'firstPenButton': instance.firstPenButton.toJson(),
       'secondPenButton': instance.secondPenButton.toJson(),
       'touch': instance.touch.toJson(),

--- a/app/lib/handlers/laser.dart
+++ b/app/lib/handlers/laser.dart
@@ -112,8 +112,9 @@ class LaserHandler extends Handler<LaserTool> with ColoredHandler {
     final penOnlyInput = settings.penOnlyInput;
     localPosition = PointerManipulationHandler.calculatePointerPosition(
         currentIndexCubit.state, localPosition, viewportSize, transform);
-    if (penOnlyInput && (kind != PointerDeviceKind.stylus &&
-        kind != PointerDeviceKind.invertedStylus)) {
+    if (penOnlyInput &&
+        (kind != PointerDeviceKind.stylus &&
+            kind != PointerDeviceKind.invertedStylus)) {
       return;
     }
     if (!_elements.containsKey(pointer) && !forceCreate) {

--- a/app/lib/handlers/laser.dart
+++ b/app/lib/handlers/laser.dart
@@ -112,7 +112,8 @@ class LaserHandler extends Handler<LaserTool> with ColoredHandler {
     final penOnlyInput = settings.penOnlyInput;
     localPosition = PointerManipulationHandler.calculatePointerPosition(
         currentIndexCubit.state, localPosition, viewportSize, transform);
-    if (penOnlyInput && kind != PointerDeviceKind.stylus) {
+    if (penOnlyInput && (kind != PointerDeviceKind.stylus &&
+        kind != PointerDeviceKind.invertedStylus)) {
       return;
     }
     if (!_elements.containsKey(pointer) && !forceCreate) {

--- a/app/lib/handlers/pen.dart
+++ b/app/lib/handlers/pen.dart
@@ -89,8 +89,9 @@ class PenHandler extends Handler<PenTool> with ColoredHandler {
     final penOnlyInput = settings.penOnlyInput;
     if (lastPosition[pointer] == localPos) return;
     lastPosition[pointer] = localPos;
-    if (penOnlyInput && (kind != PointerDeviceKind.stylus &&
-        kind != PointerDeviceKind.invertedStylus)) {
+    if (penOnlyInput &&
+        (kind != PointerDeviceKind.stylus &&
+            kind != PointerDeviceKind.invertedStylus)) {
       return;
     }
     double zoom = data.zoomDependent ? transform.size : 1;

--- a/app/lib/handlers/pen.dart
+++ b/app/lib/handlers/pen.dart
@@ -89,7 +89,8 @@ class PenHandler extends Handler<PenTool> with ColoredHandler {
     final penOnlyInput = settings.penOnlyInput;
     if (lastPosition[pointer] == localPos) return;
     lastPosition[pointer] = localPos;
-    if (penOnlyInput && kind != PointerDeviceKind.stylus) {
+    if (penOnlyInput && (kind != PointerDeviceKind.stylus &&
+        kind != PointerDeviceKind.invertedStylus)) {
       return;
     }
     double zoom = data.zoomDependent ? transform.size : 1;

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -18,6 +18,7 @@
   "includeEraser": "Include eraser?",
   "thinning": "Thinning",
   "pen": "Pen",
+  "invertedPen": "Inverted Pen",
   "eraser": "Eraser",
   "pathEraser": "Path eraser",
   "label": "Label",

--- a/app/lib/settings/inputs/pen.dart
+++ b/app/lib/settings/inputs/pen.dart
@@ -95,7 +95,10 @@ class PenInputSettings extends StatelessWidget {
                             inputName: AppLocalizations.of(context).invertedPen,
                             currentValue: config.invertedPen,
                             defaultValue: InputMappingDefault.invertedPen,
-                            icon: const PhosphorIcon(PhosphorIconsLight.pen),
+                            icon: Transform.flip(
+                                flipX: true,
+                                flipY: true,
+                                child: PhosphorIcon(PhosphorIconsLight.pen)),
                             onChanged: (value) {
                               final cubit = context.read<SettingsCubit>();
                               cubit.changeInputConfiguration(

--- a/app/lib/settings/inputs/pen.dart
+++ b/app/lib/settings/inputs/pen.dart
@@ -92,6 +92,20 @@ class PenInputSettings extends StatelessWidget {
                             },
                           ),
                           InputMappingListTile(
+                            inputName: AppLocalizations.of(context).invertedPen,
+                            currentValue: config.invertedPen,
+                            defaultValue: InputMappingDefault.invertedPen,
+                            icon: const PhosphorIcon(PhosphorIconsLight.pen),
+                            onChanged: (value) {
+                              final cubit = context.read<SettingsCubit>();
+                              cubit.changeInputConfiguration(
+                                config.copyWith(
+                                  invertedPen: value,
+                                ),
+                              );
+                            },
+                          ),
+                          InputMappingListTile(
                             inputName: AppLocalizations.of(context).first,
                             currentValue: config.firstPenButton,
                             defaultValue: InputMappingDefault.firstPenButton,

--- a/app/lib/views/view.dart
+++ b/app/lib/views/view.dart
@@ -115,6 +115,8 @@ class _MainViewViewportState extends State<MainViewViewport>
               } else if ((buttons & kPrimaryStylusButton) != 0) {
                 nextPointerMapping = config.firstPenButton;
               }
+            case PointerDeviceKind.invertedStylus:
+              nextPointerMapping = config.invertedPen;
             default:
               nextPointerMapping = null;
           }

--- a/app/lib/widgets/input_mapping_list_tile.dart
+++ b/app/lib/widgets/input_mapping_list_tile.dart
@@ -8,7 +8,7 @@ class InputMappingListTile extends StatelessWidget {
   final String inputName;
   final InputMapping currentValue;
   final InputMapping defaultValue;
-  final Icon icon;
+  final Widget icon;
   final ValueChanged<InputMapping> onChanged;
 
   const InputMappingListTile({


### PR DESCRIPTION
This PR allows the "invertedStylus" pointer type to be mapped from the pen input settings. It also makes sure that this type of input is permitted when "pen input only" is turned on.

I expect this will fix #270 as some brands of stylus use this device type for their additional buttons. This also adds great support for Microsoft's pens, which use this type quite literally when the pen is inverted, as they allow you to use the back of the pen as an eraser.