### PR TITLE
Respect input mappings with select tool

### DIFF
--- a/app/lib/handlers/select.dart
+++ b/app/lib/handlers/select.dart
@@ -162,7 +162,10 @@ class SelectHandler extends Handler<SelectTool> {
     if (_selectionManager.isTransforming) {
       _submitTransform(context.getDocumentBloc());
     }
-    if (_selected.isEmpty) {
+    final cameraTransform = context.getCameraTransform();
+    final globalPos = cameraTransform.localToGlobal(details.localPosition);
+    final selectionRect = getSelectionRect();
+    if (selectionRect == null || !selectionRect.contains(globalPos)) {
       _onSelectionContext(context, details.localPosition);
     }
   }

--- a/app/lib/handlers/select.dart
+++ b/app/lib/handlers/select.dart
@@ -162,6 +162,9 @@ class SelectHandler extends Handler<SelectTool> {
     if (_selectionManager.isTransforming) {
       _submitTransform(context.getDocumentBloc());
     }
+    if (_selected.isEmpty) {
+      _onSelectionContext(context, details.localPosition);
+    }
   }
 
   bool _startLongPress = false;

--- a/app/lib/handlers/select.dart
+++ b/app/lib/handlers/select.dart
@@ -315,9 +315,20 @@ class SelectHandler extends Handler<SelectTool> {
   }
 
   @override
-  bool canChange(PointerDownEvent event, EventContext context) =>
-      event.kind == PointerDeviceKind.mouse &&
-      event.buttons != kSecondaryMouseButton;
+  bool canChange(PointerDownEvent event, EventContext context) {
+    final cameraTransform = context.getCameraTransform();
+    final globalPos = cameraTransform.localToGlobal(event.localPosition);
+    final selectionRect = getSelectionRect();
+    final shouldTransform = _selectionManager.shouldTransform(globalPos,
+        cameraTransform.size, context.getSettings().touchSensitivity);
+    if (selectionRect != null && selectionRect.contains(globalPos)) {
+      return false;
+    }
+    if (shouldTransform) {
+      return false;
+    }
+    return true;
+  }
 
   RulerHandler? _ruler;
   Offset? _rulerRotationStart;


### PR DESCRIPTION
This PR fixes #821. Rather than disabling input mappings when the select tool is active, it only disables input mappings when directly interacting with a previously selected region. This way the select tool will stay enabled during move, transform, and opening of the context menu for a selection, but once the user interacts with the canvas outside of the selected region the tool will once again use the input mapping settings.