### PR TITLE
Correct the templates link in astro.config.mjs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -70,7 +70,7 @@ export default defineConfig({
             },
             {
               ...getSidebarTranslatedLabel("Templates"),
-              link: "/docs/v2/areas/",
+              link: "/docs/v2/templates/",
             },
             {
               ...getSidebarTranslatedLabel("Pages"),


### PR DESCRIPTION
I forgot to change the link to direct the user to the templates documentation.

After writing the documentation, I probably got too dizzy and forgot everything necessary.