### PR TITLE
Fix rotated pen element sudden offset when nudged

### DIFF
--- a/app/lib/renderers/renderer.dart
+++ b/app/lib/renderers/renderer.dart
@@ -450,7 +450,7 @@ abstract class Renderer<T> {
     if ((scaleX != 1 || scaleY != 1) && (this.rotation % 360) != 0) {
       final w = rect.width;
       final h = rect.height;
-      final expandedRect = this.expandedRect ?? rect;
+      final expandedRect = _expandedAabbFor(rect, radians);
 
       if (w > 0 && h > 0) {
         final absC = cos(radians).abs();


### PR DESCRIPTION
Pen renderer uses a different expandedRect than the base class. Therefore the expandedRect in renderer has to be evaluated using the pen renderer rect